### PR TITLE
feat(auth): add TTL-based expiry to token cache

### DIFF
--- a/examples/OrasProject.Oras.Examples.AuthChallengeRecovery/AuthChallengeRecoveryExamples.cs
+++ b/examples/OrasProject.Oras.Examples.AuthChallengeRecovery/AuthChallengeRecoveryExamples.cs
@@ -126,7 +126,7 @@ public sealed class ColdReDeriveAuthChallengeHandler : IAuthChallengeHandler
                 return new AuthChallengeResolution
                 {
                     Scheme = Challenge.Scheme.Basic,
-                    Token = await context.FetchBasicTokenAsync(cancellationToken),
+                    Token = (await context.FetchBasicTokenAsync(cancellationToken)).Token,
                     CacheScopeKey = string.Empty,
                 };
 
@@ -144,8 +144,8 @@ public sealed class ColdReDeriveAuthChallengeHandler : IAuthChallengeHandler
                 return new AuthChallengeResolution
                 {
                     Scheme = Challenge.Scheme.Bearer,
-                    Token = await context.FetchBearerTokenAsync(
-                        realm, service ?? string.Empty, scopes, cancellationToken),
+                    Token = (await context.FetchBearerTokenAsync(
+                        realm, service ?? string.Empty, scopes, cancellationToken)).Token,
                     CacheScopeKey = cacheKey,
                 };
 

--- a/src/OrasProject.Oras/OrasProject.Oras.csproj
+++ b/src/OrasProject.Oras/OrasProject.Oras.csproj
@@ -39,6 +39,7 @@ limitations under the License.
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.6" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallengeContext.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallengeContext.cs
@@ -178,8 +178,8 @@ public sealed class AuthChallengeContext
     /// <param name="service">The service identifier from the challenge.</param>
     /// <param name="scopes">The scopes to request for the token.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-    /// <returns>The fetched bearer token.</returns>
-    public Task<string> FetchBearerTokenAsync(
+    /// <returns>The fetched bearer token and its server-declared expiry, when present.</returns>
+    public Task<TokenResult> FetchBearerTokenAsync(
         string realm,
         string service,
         IReadOnlyList<string> scopes,
@@ -197,9 +197,12 @@ public sealed class AuthChallengeContext
     /// <see cref="Host"/> from the client's credential provider.
     /// </summary>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-    /// <returns>The base64-encoded Basic credential.</returns>
-    public Task<string> FetchBasicTokenAsync(CancellationToken cancellationToken = default)
-        => _client.FetchBasicAuthAsync(Host, cancellationToken);
+    /// <returns>The base64-encoded Basic credential (Basic credentials do not expire).</returns>
+    public async Task<TokenResult> FetchBasicTokenAsync(CancellationToken cancellationToken = default)
+    {
+        var token = await _client.FetchBasicAuthAsync(Host, cancellationToken).ConfigureAwait(false);
+        return new TokenResult(token, null);
+    }
 
     /// <summary>
     /// Attempts to read a still-cached token for <see cref="Host"/> at the given scheme and

--- a/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallengeResolution.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallengeResolution.cs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
 /// <summary>
@@ -51,4 +53,12 @@ public sealed class AuthChallengeResolution
     /// requests. Defaults to <c>true</c>.
     /// </summary>
     public bool Cache { get; init; } = true;
+
+    /// <summary>
+    /// The server-declared absolute expiry of <see cref="Token"/> (derived from the token
+    /// response's <c>expires_in</c>/<c>issued_at</c>), or <c>null</c> when the registry did not
+    /// provide one. When <c>null</c>, the client falls back to the token's JWT <c>exp</c> claim and
+    /// then a default time-to-live. Ignored for Basic tokens and when <see cref="Cache"/> is <c>false</c>.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
 }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Cache.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Cache.cs
@@ -11,9 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Concurrent;
 using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
@@ -22,31 +20,20 @@ public sealed class Cache : ICache
 {
     #region private members
     /// <summary>
-    /// CacheEntry represents a cache entry for storing authentication tokens associated with a
-    /// specific challenge scheme.
-    /// </summary>
-    /// <param name="Scheme">The authentication scheme associated with the cache entry.</param>
-    /// <param name="Tokens">
-    /// A dictionary containing authentication tokens, where the key is the scopes and the value
-    /// is the token itself.
-    /// </param>
-    private sealed record CacheEntry(Challenge.Scheme Scheme, Dictionary<string, string> Tokens);
-
-    /// <summary>
     /// The underlying memory cache used to store authentication schemes and tokens.
     /// </summary>
     private readonly IMemoryCache _memoryCache;
 
     /// <summary>
-    /// Dictionary to store per-key locks to ensure thread-safety while allowing
-    /// concurrent operations on different cache keys.
+    /// Prefix for scheme cache keys to prevent collisions with other users of the same memory cache.
     /// </summary>
-    private readonly ConcurrentDictionary<string, object> _locks = new();
+    private const string _schemeKeyPrefix = "ORAS_AUTH_SCHEME_";
 
     /// <summary>
-    /// Prefix for cache keys to prevent collisions with other users of the same memory cache.
+    /// Prefix for token cache keys. Each token is stored as its own entry so the memory cache can
+    /// evict it independently the moment it expires.
     /// </summary>
-    private const string _cacheKeyPrefix = "ORAS_AUTH_";
+    private const string _tokenKeyPrefix = "ORAS_AUTH_TOKEN_";
 
     /// <summary>
     /// Default cache entry options with size=1.
@@ -58,16 +45,27 @@ public sealed class Cache : ICache
     };
 
     /// <summary>
-    /// Generates a consistent cache key from the registry and optional PartitionId.
+    /// Builds the scheme cache key for a registry (optionally partitioned).
     /// Uses pipe (|) as delimiter since it cannot appear in registry hostnames.
     /// </summary>
-    /// <param name="registry">The registry host.</param>
-    /// <param name="partitionId">Optional cache partition identifier.</param>
-    /// <returns>A prefixed cache key.</returns>
-    private static string GetCacheKey(string registry, string? partitionId) =>
+    private static string GetSchemeKey(string registry, string? partitionId) =>
         string.IsNullOrEmpty(partitionId)
-            ? $"{_cacheKeyPrefix}{registry}"
-            : $"{_cacheKeyPrefix}{partitionId}|{registry}";
+            ? $"{_schemeKeyPrefix}{registry}"
+            : $"{_schemeKeyPrefix}{partitionId}|{registry}";
+
+    /// <summary>
+    /// Builds the token cache key for a registry/scheme/scope (optionally partitioned).
+    /// The scheme is part of the key so tokens for different schemes never collide.
+    /// </summary>
+    private static string GetTokenKey(
+        string registry,
+        Challenge.Scheme scheme,
+        string scopeKey,
+        string? partitionId)
+    {
+        var partitionPrefix = string.IsNullOrEmpty(partitionId) ? string.Empty : $"{partitionId}|";
+        return $"{_tokenKeyPrefix}{partitionPrefix}{registry}|{(int)scheme}|{scopeKey}";
+    }
     #endregion
 
     /// <summary>
@@ -111,10 +109,9 @@ public sealed class Cache : ICache
     /// </returns>
     public bool TryGetScheme(string registry, out Challenge.Scheme scheme, string? partitionId = null)
     {
-        var cacheKey = GetCacheKey(registry, partitionId);
-        if (_memoryCache.TryGetValue(cacheKey, out CacheEntry? cacheEntry) && cacheEntry != null)
+        if (_memoryCache.TryGetValue(GetSchemeKey(registry, partitionId), out Challenge.Scheme cachedScheme))
         {
-            scheme = cacheEntry.Scheme;
+            scheme = cachedScheme;
             return true;
         }
 
@@ -123,33 +120,33 @@ public sealed class Cache : ICache
     }
 
     /// <summary>
-    /// Sets or updates the cache for a specific registry and authentication scheme.
+    /// Sets or updates the cache for a specific registry, authentication scheme, and scope.
     /// </summary>
     /// <param name="registry">The registry host (e.g., "docker.io").</param>
     /// <param name="scheme">The authentication scheme associated with the cache entry.</param>
     /// <param name="scopeKey">
-    /// The OAuth2 scope key used to identify the token within the cache entry.
+    /// The OAuth2 scope key used to identify the token within the cache.
     /// </param>
     /// <param name="token">The token to be stored in the cache.</param>
+    /// <param name="expiresAt">
+    /// The absolute instant at which the token entry should expire. When provided, the underlying
+    /// memory cache evicts the token automatically once this instant passes. When <c>null</c>
+    /// (e.g., for Basic credentials), the token does not expire on a timer.
+    /// </param>
     /// <param name="partitionId">
     /// Optional cache partition identifier. When provided, tokens are isolated by this ID,
     /// enabling multi-partition scenarios where different credentials are used for the same registry.
     /// </param>
     /// <remarks>
     /// <para>
-    /// If the registry already exists in the cache:
-    /// <list type="bullet">
-    /// <item>
-    /// If the provided scheme differs from the existing scheme, the cache entry is replaced with
-    /// a new one.
-    /// </item>
-    /// <item> Otherwise, the token is added or updated in the existing cache entry.</item>
-    /// </list>
+    /// The scheme is stored as its own long-lived entry, and each token is stored as a separate
+    /// entry keyed by registry, scheme, and scope. This lets the memory cache expire individual
+    /// tokens on their own schedule without dropping the scheme or other still-valid tokens.
     /// </para>
     /// <para>
-    /// This method uses the <see cref="CacheEntryOptions"/> property if set, or falls back to
-    /// the default options with size=1. Using these options ensures proper cache eviction behavior
-    /// when size limits are configured.
+    /// This method uses the <see cref="MemoryCacheEntryOptions.Size"/> from
+    /// <see cref="CacheEntryOptions"/> if set, or falls back to size=1. Setting the size ensures
+    /// proper cache eviction behavior when the underlying cache has a size limit configured.
     /// </para>
     /// </remarks>
     public void SetCache(
@@ -157,32 +154,62 @@ public sealed class Cache : ICache
         Challenge.Scheme scheme,
         string scopeKey,
         string token,
+        DateTimeOffset? expiresAt = null,
         string? partitionId = null)
     {
-        var cacheKey = GetCacheKey(registry, partitionId);
-        var lockObj = _locks.GetOrAdd(cacheKey, _ => new object());
-        // Lock for atomicity
-        lock (lockObj)
+        var entryOptions = CacheEntryOptions ?? _defaultCacheEntryOptions;
+
+        // The scheme is long-lived and lightweight; store it as a size-free entry so that token
+        // expiry never drops it (which would force a re-challenge) and it doesn't consume the
+        // caller's size budget.
+        _memoryCache.Set(
+            GetSchemeKey(registry, partitionId),
+            scheme,
+            new MemoryCacheEntryOptions { Size = 0 });
+
+        // The token entry inherits the caller's configured options (size, callbacks, sliding/absolute
+        // expiration). A supplied token expiry takes precedence over any configured absolute expiration.
+        _memoryCache.Set(
+            GetTokenKey(registry, scheme, scopeKey, partitionId),
+            token,
+            BuildTokenEntryOptions(entryOptions, expiresAt));
+    }
+
+    /// <summary>
+    /// Builds the memory cache options for a token entry by cloning the caller-configured
+    /// <see cref="CacheEntryOptions"/> and, when a token expiry is supplied, applying it as the
+    /// authoritative absolute expiration.
+    /// </summary>
+    private static MemoryCacheEntryOptions BuildTokenEntryOptions(
+        MemoryCacheEntryOptions source,
+        DateTimeOffset? expiresAt)
+    {
+        var options = new MemoryCacheEntryOptions
         {
-            if (_memoryCache.TryGetValue(cacheKey, out CacheEntry? oldEntry) &&
-                oldEntry != null &&
-                scheme == oldEntry.Scheme)
-            {
-                // When the scheme matches, update the token in the existing entry
-                oldEntry.Tokens[scopeKey] = token;
-                return;
-            }
+            Size = source.Size ?? 1,
+            Priority = source.Priority,
+            SlidingExpiration = source.SlidingExpiration,
+            AbsoluteExpiration = source.AbsoluteExpiration,
+            AbsoluteExpirationRelativeToNow = source.AbsoluteExpirationRelativeToNow,
+        };
 
-            // Otherwise, set a new entry
-            var tokens = new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                [scopeKey] = token
-            };
-            var newEntry = new CacheEntry(scheme, tokens);
-
-            var entryOptions = CacheEntryOptions ?? _defaultCacheEntryOptions;
-            _memoryCache.Set(cacheKey, newEntry, entryOptions);
+        foreach (var callback in source.PostEvictionCallbacks)
+        {
+            options.PostEvictionCallbacks.Add(callback);
         }
+
+        foreach (var expirationToken in source.ExpirationTokens)
+        {
+            options.ExpirationTokens.Add(expirationToken);
+        }
+
+        if (expiresAt.HasValue)
+        {
+            options.AbsoluteExpiration = expiresAt.Value;
+            options.AbsoluteExpirationRelativeToNow = null;
+        }
+
+        return options;
     }
 
     /// <summary>
@@ -213,11 +240,10 @@ public sealed class Cache : ICache
         out string token,
         string? partitionId = null)
     {
-        var cacheKey = GetCacheKey(registry, partitionId);
-        if (_memoryCache.TryGetValue(cacheKey, out CacheEntry? cacheEntry) &&
-            cacheEntry != null &&
-            cacheEntry.Scheme == scheme &&
-            cacheEntry.Tokens.TryGetValue(scopeKey, out var cachedToken))
+        // An expired token entry is evicted by the memory cache and read here as a miss,
+        // which causes the caller to acquire a fresh token.
+        if (_memoryCache.TryGetValue(GetTokenKey(registry, scheme, scopeKey, partitionId), out string? cachedToken) &&
+            cachedToken != null)
         {
             token = cachedToken;
             return true;

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Caching.Memory;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -240,6 +241,19 @@ public class Client : IClient
     public bool ForceAttemptOAuth2 { get; set; }
 
     /// <summary>
+    /// The default time-to-live applied to a cached token when neither the token response
+    /// (<c>expires_in</c>) nor the token's JWT <c>exp</c> claim provides a usable expiry.
+    /// Defaults to 5 minutes.
+    /// </summary>
+    public TimeSpan DefaultTokenExpiry { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Clock used for token-expiry calculations. Overridable for testing; defaults to
+    /// <see cref="System.TimeProvider.System"/>.
+    /// </summary>
+    internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+    /// <summary>
     /// defaultClientID specifies the default client ID used in OAuth2.
     /// </summary>
     private const string _defaultClientId = "oras-dotnet";
@@ -435,7 +449,7 @@ public class Client : IClient
     /// <exception cref="AuthenticationException">
     /// Thrown when credentials are missing or invalid.
     /// </exception>
-    internal async Task<string> FetchBearerAuthAsync(
+    internal async Task<TokenResult> FetchBearerAuthAsync(
         string registry,
         string realm,
         string service,
@@ -461,7 +475,7 @@ public class Client : IClient
                 .ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(accessToken))
             {
-                return accessToken;
+                return new TokenResult(accessToken, null);
             }
         }
 
@@ -469,7 +483,7 @@ public class Client : IClient
             .ConfigureAwait(false);
         if (!string.IsNullOrEmpty(credential.AccessToken))
         {
-            return credential.AccessToken;
+            return new TokenResult(credential.AccessToken, null);
         }
         if (credential.IsEmpty() ||
             (string.IsNullOrWhiteSpace(credential.RefreshToken) && !ForceAttemptOAuth2))
@@ -505,7 +519,8 @@ public class Client : IClient
     /// <param name="password">The password for basic authentication (optional).</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the fetched token as a string.
+    /// A task that represents the asynchronous operation. The task result contains the fetched token
+    /// and its server-declared expiry, when present.
     /// </returns>
     /// <exception cref="AuthenticationException">
     /// Thrown when both "access_token" and "token" are missing or empty in the response.
@@ -513,7 +528,7 @@ public class Client : IClient
     /// <exception cref="HttpRequestException">
     /// Thrown when the HTTP request fails or the response status code is not OK.
     /// </exception>
-    internal async Task<string> FetchDistributionTokenAsync(
+    internal async Task<TokenResult> FetchDistributionTokenAsync(
         string realm,
         string service,
         IList<string> scopes,
@@ -558,14 +573,16 @@ public class Client : IClient
         using var doc = JsonDocument.Parse(responseBody);
         var root = doc.RootElement;
 
+        var expiresAt = ParseServerExpiry(root);
+
         if (root.TryGetProperty("access_token", out var accessToken) && !string.IsNullOrWhiteSpace(accessToken.GetString()))
         {
-            return accessToken.GetString()!;
+            return new TokenResult(accessToken.GetString()!, expiresAt);
         }
 
         if (root.TryGetProperty("token", out var token) && !string.IsNullOrWhiteSpace(token.GetString()))
         {
-            return token.GetString()!;
+            return new TokenResult(token.GetString()!, expiresAt);
         }
 
         throw new AuthenticationException("Both AccessToken and Token are empty or missing");
@@ -586,7 +603,7 @@ public class Client : IClient
     /// <exception cref="HttpRequestException">
     /// Thrown when there is an issue with the HTTP request or response.
     /// </exception>
-    internal async Task<string> FetchOauth2TokenAsync(
+    internal async Task<TokenResult> FetchOauth2TokenAsync(
         string realm,
         string service,
         IList<string> scopes,
@@ -640,10 +657,100 @@ public class Client : IClient
         var root = doc.RootElement;
         if (root.TryGetProperty("access_token", out var accessToken) && !string.IsNullOrEmpty(accessToken.ToString()))
         {
-            return accessToken.ToString();
+            return new TokenResult(accessToken.ToString(), ParseServerExpiry(root));
         }
 
         throw new AuthenticationException("AccessToken is empty or missing");
+    }
+
+    /// <summary>
+    /// Computes the server-declared token expiry from a token endpoint response using the
+    /// <c>expires_in</c> (seconds) and optional <c>issued_at</c> (RFC 3339) fields, per the
+    /// distribution token specification. Returns <c>null</c> when no usable <c>expires_in</c> is present.
+    /// </summary>
+    private DateTimeOffset? ParseServerExpiry(JsonElement root)
+    {
+        if (!root.TryGetProperty("expires_in", out var expiresInElement))
+        {
+            return null;
+        }
+
+        int expiresInSeconds;
+        switch (expiresInElement.ValueKind)
+        {
+            case JsonValueKind.Number when expiresInElement.TryGetInt32(out var number):
+                expiresInSeconds = number;
+                break;
+            case JsonValueKind.String when int.TryParse(
+                expiresInElement.GetString(),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var parsed):
+                expiresInSeconds = parsed;
+                break;
+            default:
+                return null;
+        }
+
+        if (expiresInSeconds <= 0)
+        {
+            return null;
+        }
+
+        var issuedAt = TimeProvider.GetUtcNow();
+        if (root.TryGetProperty("issued_at", out var issuedAtElement) &&
+            issuedAtElement.ValueKind == JsonValueKind.String &&
+            DateTimeOffset.TryParse(
+                issuedAtElement.GetString(),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out var parsedIssuedAt))
+        {
+            issuedAt = parsedIssuedAt;
+        }
+
+        return issuedAt.AddSeconds(expiresInSeconds);
+    }
+
+    /// <summary>
+    /// Caches the token produced for an authentication challenge, resolving its expiry from the
+    /// server-declared value, the token's JWT <c>exp</c> claim, or <see cref="DefaultTokenExpiry"/>.
+    /// Basic credentials are cached without a timed expiry; a token that resolves to an already-past
+    /// expiry is not cached.
+    /// </summary>
+    private void CacheResolvedToken(string host, AuthChallengeResolution resolution, string? partitionId)
+    {
+        if (resolution.Scheme == Challenge.Scheme.Basic)
+        {
+            Cache.SetCache(
+                host,
+                resolution.Scheme,
+                resolution.CacheScopeKey,
+                resolution.Token,
+                expiresAt: null,
+                partitionId);
+            return;
+        }
+
+        var expiresAt = TokenExpiry.Resolve(
+            resolution.Token,
+            resolution.ExpiresAt,
+            TimeProvider,
+            DefaultTokenExpiry);
+
+        if (expiresAt <= TimeProvider.GetUtcNow())
+        {
+            // Token is already expired; caching it would be a guaranteed miss.
+            return;
+        }
+
+        Cache.SetCache(
+            host,
+            resolution.Scheme,
+            resolution.CacheScopeKey,
+            resolution.Token,
+            expiresAt,
+            partitionId);
     }
 
     /// <summary>
@@ -805,7 +912,7 @@ public class Client : IClient
 
             if (resolution.Cache)
             {
-                Cache.SetCache(host, resolution.Scheme, resolution.CacheScopeKey, resolution.Token, partitionId);
+                CacheResolvedToken(host, resolution, partitionId);
             }
 
             var schemeName = resolution.Scheme == Challenge.Scheme.Basic ? "Basic" : "Bearer";

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultAuthChallengeHandler.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultAuthChallengeHandler.cs
@@ -47,8 +47,9 @@ public sealed class DefaultAuthChallengeHandler : IAuthChallengeHandler
                     return new AuthChallengeResolution
                     {
                         Scheme = Challenge.Scheme.Basic,
-                        Token = basicToken,
+                        Token = basicToken.Token,
                         CacheScopeKey = string.Empty,
+                        ExpiresAt = basicToken.ExpiresAt,
                     };
                 }
             case Challenge.Scheme.Bearer:
@@ -105,8 +106,9 @@ public sealed class DefaultAuthChallengeHandler : IAuthChallengeHandler
         return new AuthChallengeResolution
         {
             Scheme = Challenge.Scheme.Bearer,
-            Token = bearerToken,
+            Token = bearerToken.Token,
             CacheScopeKey = cacheKey,
+            ExpiresAt = bearerToken.ExpiresAt,
         };
     }
 }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ICache.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ICache.cs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
 public interface ICache
@@ -34,7 +36,7 @@ public interface ICache
     bool TryGetScheme(string registry, out Challenge.Scheme scheme, string? partitionId = null);
 
     /// <summary>
-    /// SetCache sets or updates the cache for a specific registry and authentication scheme.
+    /// SetCache sets or updates the cache for a specific registry, authentication scheme, and scope.
     /// </summary>
     /// <param name="registry">The registry host (e.g., "docker.io").</param>
     /// <param name="scheme">The authentication scheme associated with the cache entry.</param>
@@ -42,6 +44,10 @@ public interface ICache
     /// The OAuth2 scope key used to identify the token within the cache entry.
     /// </param>
     /// <param name="token">The token to be stored in the cache.</param>
+    /// <param name="expiresAt">
+    /// The absolute instant at which the token should expire and be evicted, or <c>null</c> for a
+    /// token that does not expire on a timer (e.g., a Basic credential).
+    /// </param>
     /// <param name="partitionId">
     /// Optional cache partition identifier. When provided, tokens are isolated by this ID,
     /// enabling multi-partition scenarios where different credentials are used for the same registry.
@@ -51,6 +57,7 @@ public interface ICache
         Challenge.Scheme scheme,
         string scopeKey,
         string token,
+        DateTimeOffset? expiresAt = null,
         string? partitionId = null);
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/JwtExpiry.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/JwtExpiry.cs
@@ -1,0 +1,87 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Safely extracts the expiration (<c>exp</c> claim) from a JWT access token <b>without validating
+/// its signature, issuer, or audience</b>. The token originates from an upstream registry and is
+/// treated as untrusted input: it is only read to determine a cache time-to-live, never to make a
+/// security decision. Any malformed, opaque, or oversized input yields <c>false</c> rather than
+/// throwing.
+/// </summary>
+internal static class JwtExpiry
+{
+    /// <summary>
+    /// Upper bound on the token size accepted for parsing. Registry access tokens are well under
+    /// this; the bound caps work performed on maliciously oversized input.
+    /// </summary>
+    private const int MaxJwtSizeInBytes = 64 * 1024;
+
+    // JwtSecurityTokenHandler is thread-safe for reading; shared to avoid per-call allocation.
+    private static readonly JwtSecurityTokenHandler _handler = new()
+    {
+        MaximumTokenSizeInBytes = MaxJwtSizeInBytes,
+    };
+
+    /// <summary>
+    /// Attempts to read the <c>exp</c> claim of a JWT and return it as an absolute UTC instant.
+    /// </summary>
+    /// <param name="token">
+    /// The candidate token. Opaque (non-JWT) tokens are expected and yield <c>false</c>.
+    /// </param>
+    /// <param name="expiration">The parsed expiry on success; otherwise <c>default</c>.</param>
+    /// <returns>
+    /// <c>true</c> if <paramref name="token"/> is a JWT with a parseable <c>exp</c> claim;
+    /// otherwise <c>false</c> (opaque token, missing/invalid <c>exp</c>, oversized, or malformed).
+    /// </returns>
+    public static bool TryGetExpiration(string token, out DateTimeOffset expiration)
+    {
+        expiration = default;
+        if (string.IsNullOrWhiteSpace(token) || !_handler.CanReadToken(token))
+        {
+            // Opaque/non-JWT tokens are a normal case, not an error.
+            return false;
+        }
+
+        try
+        {
+            var jwt = _handler.ReadJwtToken(token);
+            if (jwt.ValidTo == DateTime.MinValue)
+            {
+                // No 'exp' claim present in the payload.
+                return false;
+            }
+
+            // JwtSecurityToken.ValidTo is UTC; make the kind explicit for DateTimeOffset.
+            expiration = new DateTimeOffset(DateTime.SpecifyKind(jwt.ValidTo, DateTimeKind.Utc));
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (SecurityTokenException)
+        {
+            return false;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/TokenExpiry.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/TokenExpiry.cs
@@ -1,0 +1,57 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Resolves the absolute expiry used to cache a registry token, applying a fixed precedence:
+/// <list type="number">
+/// <item>the server-declared expiry (<c>expires_in</c>/<c>issued_at</c> from the token response);</item>
+/// <item>the token's JWT <c>exp</c> claim (read without signature validation);</item>
+/// <item>a default time-to-live.</item>
+/// </list>
+/// </summary>
+internal static class TokenExpiry
+{
+    /// <summary>
+    /// Resolves the absolute expiry for <paramref name="token"/>.
+    /// </summary>
+    /// <param name="token">The token to be cached (used only for JWT <c>exp</c> extraction).</param>
+    /// <param name="serverExpiresAt">The server-declared expiry, or <c>null</c> if not provided.</param>
+    /// <param name="timeProvider">Clock used for the default-TTL fallback.</param>
+    /// <param name="defaultTtl">The TTL applied when no expiry can be determined.</param>
+    /// <returns>The absolute instant at which the cached token should expire.</returns>
+    public static DateTimeOffset Resolve(
+        string token,
+        DateTimeOffset? serverExpiresAt,
+        TimeProvider timeProvider,
+        TimeSpan defaultTtl)
+    {
+        // 1. Server-declared expiry from the token response.
+        if (serverExpiresAt is { } expiresAt)
+        {
+            return expiresAt;
+        }
+
+        // 2. JWT 'exp' claim, parsed safely (opaque tokens fall through).
+        if (JwtExpiry.TryGetExpiration(token, out var jwtExpiry))
+        {
+            return jwtExpiry;
+        }
+
+        // 3. Default time-to-live.
+        return timeProvider.GetUtcNow() + defaultTtl;
+    }
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/TokenResult.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/TokenResult.cs
@@ -1,0 +1,29 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// The outcome of fetching a token from a registry authentication endpoint: the token itself and,
+/// when the endpoint declared one, the absolute expiry derived from the token response.
+/// </summary>
+/// <param name="Token">The access (bearer) token, or the base64 <c>username:password</c> for Basic.</param>
+/// <param name="ExpiresAt">
+/// The server-declared absolute expiry — computed as <c>issued_at + expires_in</c> per the
+/// distribution token spec — or <c>null</c> when the response did not include a usable
+/// <c>expires_in</c>. When <c>null</c>, callers fall back to the token's JWT <c>exp</c> claim and
+/// then to a default time-to-live.
+/// </param>
+public sealed record TokenResult(string Token, DateTimeOffset? ExpiresAt);

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/AuthChallengeHandlerTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/AuthChallengeHandlerTest.cs
@@ -256,7 +256,7 @@ public class AuthChallengeHandlerTest
             return new AuthChallengeResolution
             {
                 Scheme = Challenge.Scheme.Bearer,
-                Token = token,
+                Token = token.Token,
                 CacheScopeKey = cacheKey,
             };
         }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/AuthTestHelpers.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/AuthTestHelpers.cs
@@ -1,0 +1,57 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Text;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+/// <summary>
+/// Shared helpers for authentication token cache tests.
+/// </summary>
+internal static class AuthTestHelpers
+{
+    /// <summary>
+    /// Builds an (unsigned) JWT string whose payload carries the given <paramref name="expUnixSeconds"/>
+    /// as the <c>exp</c> claim (omitted when null). The token is not signed — it exists only to exercise
+    /// expiry extraction, which does not validate signatures.
+    /// </summary>
+    public static string CreateJwt(long? expUnixSeconds)
+    {
+        var header = Base64Url("{\"alg\":\"HS256\",\"typ\":\"JWT\"}");
+        var payloadJson = expUnixSeconds.HasValue
+            ? $"{{\"exp\":{expUnixSeconds.Value},\"sub\":\"test\"}}"
+            : "{\"sub\":\"test\"}";
+        var payload = Base64Url(payloadJson);
+        var signature = Base64Url("signature");
+        return $"{header}.{payload}.{signature}";
+    }
+
+    private static string Base64Url(string value)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+}
+
+/// <summary>
+/// A <see cref="TimeProvider"/> whose current UTC time is fixed and settable, for deterministic tests.
+/// </summary>
+internal sealed class FixedTimeProvider : TimeProvider
+{
+    public FixedTimeProvider(DateTimeOffset utcNow) => UtcNow = utcNow;
+
+    public DateTimeOffset UtcNow { get; set; }
+
+    public override DateTimeOffset GetUtcNow() => UtcNow;
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/CacheTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/CacheTest.cs
@@ -409,8 +409,8 @@ public class CacheTest
         var key = "repository:library/nginx:pull";
 
         // Act - Set tokens for two different cache partitions
-        cache.SetCache(registry, scheme, key, "customer1-token", "customer1");
-        cache.SetCache(registry, scheme, key, "customer2-token", "customer2");
+        cache.SetCache(registry, scheme, key, "customer1-token", partitionId: "customer1");
+        cache.SetCache(registry, scheme, key, "customer2-token", partitionId: "customer2");
 
         // Assert - Each partition should have its own token
         Assert.True(cache.TryGetToken(registry, scheme, key, out var token1, "customer1"));
@@ -442,5 +442,89 @@ public class CacheTest
 
         // With different partitionId, should not find the token
         Assert.False(cache.TryGetToken(registry, scheme, key, out _, "customer1"));
+    }
+
+    [Fact]
+    public void SetCache_WithExpiresAt_TokenExpiresAfterDeadline()
+    {
+        // Arrange
+        var cache = new Cache(new MemoryCache(new MemoryCacheOptions()));
+        var registry = "test.registry";
+        var scheme = Challenge.Scheme.Bearer;
+        var key = "testKey";
+        var token = "testToken";
+
+        // Act — cache with a short absolute expiry supplied by the caller.
+        cache.SetCache(registry, scheme, key, token, expiresAt: DateTimeOffset.UtcNow.AddMilliseconds(300));
+
+        // Token is initially retrievable.
+        Assert.True(cache.TryGetToken(registry, scheme, key, out var retrieved));
+        Assert.Equal(token, retrieved);
+
+        // Wait past the deadline (with buffer).
+        Thread.Sleep(500);
+
+        var expired = false;
+        for (var i = 0; i < 3; i++)
+        {
+            if (!cache.TryGetToken(registry, scheme, key, out _))
+            {
+                expired = true;
+                break;
+            }
+            Thread.Sleep(100);
+        }
+
+        // Assert
+        Assert.True(expired, "Token should expire after its expiresAt deadline");
+    }
+
+    [Fact]
+    public void SetCache_WithExpiresAt_SchemeSurvivesTokenExpiry()
+    {
+        // Arrange
+        var cache = new Cache(new MemoryCache(new MemoryCacheOptions()));
+        var registry = "test.registry";
+        var scheme = Challenge.Scheme.Bearer;
+        var key = "testKey";
+
+        // Act
+        cache.SetCache(registry, scheme, key, "tok", expiresAt: DateTimeOffset.UtcNow.AddMilliseconds(300));
+        Thread.Sleep(500);
+
+        var tokenExpired = false;
+        for (var i = 0; i < 3; i++)
+        {
+            if (!cache.TryGetToken(registry, scheme, key, out _))
+            {
+                tokenExpired = true;
+                break;
+            }
+            Thread.Sleep(100);
+        }
+
+        // Assert — the token expired but the scheme entry is still cached.
+        Assert.True(tokenExpired, "Token should have expired");
+        Assert.True(cache.TryGetScheme(registry, out var cachedScheme), "Scheme should survive token expiry");
+        Assert.Equal(scheme, cachedScheme);
+    }
+
+    [Fact]
+    public void SetCache_WithNullExpiresAt_TokenHasNoTimedExpiry()
+    {
+        // Arrange
+        var cache = new Cache(new MemoryCache(new MemoryCacheOptions()));
+        var registry = "test.registry";
+        var scheme = Challenge.Scheme.Basic;
+        var key = "";
+        var token = "basic-token";
+
+        // Act — no expiry supplied (e.g., a Basic credential).
+        cache.SetCache(registry, scheme, key, token, expiresAt: null);
+        Thread.Sleep(200);
+
+        // Assert — still present; it is not evicted on a timer.
+        Assert.True(cache.TryGetToken(registry, scheme, key, out var retrieved));
+        Assert.Equal(token, retrieved);
     }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -182,7 +182,7 @@ public class ClientTest
             cancellationToken);
 
         // Assert
-        Assert.Equal(expectedToken, result);
+        Assert.Equal(expectedToken, result.Token);
     }
 
     [Fact]
@@ -245,7 +245,7 @@ public class ClientTest
             cancellationToken);
 
         // Assert
-        Assert.Equal("test_access_token", result);
+        Assert.Equal("test_access_token", result.Token);
     }
 
     [Fact]
@@ -395,7 +395,7 @@ public class ClientTest
             CancellationToken.None);
 
         // Assert
-        Assert.Equal(expectedToken, result);
+        Assert.Equal(expectedToken, result.Token);
     }
 
     [Fact]
@@ -449,7 +449,7 @@ public class ClientTest
             CancellationToken.None);
 
         // Assert
-        Assert.Equal(expectedToken, result);
+        Assert.Equal(expectedToken, result.Token);
     }
 
     [Fact]
@@ -566,7 +566,7 @@ public class ClientTest
             CancellationToken.None);
 
         // Assert
-        Assert.Equal("test_access_token", result);
+        Assert.Equal("test_access_token", result.Token);
 
         // with only username
         result = await client.FetchDistributionTokenAsync(
@@ -578,7 +578,7 @@ public class ClientTest
             CancellationToken.None);
 
         // Assert
-        Assert.Equal("test_access_token", result);
+        Assert.Equal("test_access_token", result.Token);
 
         // with only password
         result = await client.FetchDistributionTokenAsync(
@@ -590,7 +590,7 @@ public class ClientTest
             CancellationToken.None);
 
         // Assert
-        Assert.Equal("test_access_token", result);
+        Assert.Equal("test_access_token", result.Token);
     }
 
     [Fact]
@@ -2252,7 +2252,7 @@ public class ClientTest
             registry, realm, service, scopes, false, CancellationToken.None);
 
         // Assert
-        Assert.Equal(expectedToken, result);
+        Assert.Equal(expectedToken, result.Token);
         mockProvider.Verify(
             p => p.ResolveAccessTokenAsync(
                 registry, realm, service,
@@ -2297,7 +2297,7 @@ public class ClientTest
             registry, realm, service, scopes, false, CancellationToken.None);
 
         // Assert — fell through to credential-based auth
-        Assert.Equal(expectedToken, result);
+        Assert.Equal(expectedToken, result.Token);
         mockProvider.Verify(
             p => p.ResolveAccessTokenAsync(
                 registry, realm, service,
@@ -2350,7 +2350,7 @@ public class ClientTest
             registry, realm, service, scopes, false, CancellationToken.None);
 
         // Assert — whitespace/empty triggers fallthrough
-        Assert.Equal(expectedToken, result);
+        Assert.Equal(expectedToken, result.Token);
         mockCredentialProvider.Verify(
             p => p.ResolveCredentialAsync(
                 registry, It.IsAny<CancellationToken>()),
@@ -2400,7 +2400,7 @@ public class ClientTest
             registry, realm, service, scopes, false, CancellationToken.None);
 
         // Assert — credential provider was never consulted
-        Assert.Equal(expectedToken, result);
+        Assert.Equal(expectedToken, result.Token);
         mockCredentialProvider.Verify(
             p => p.ResolveCredentialAsync(
                 It.IsAny<string>(), It.IsAny<CancellationToken>()),
@@ -2734,5 +2734,91 @@ public class ClientTest
             () => client.SendAsync(request,
                 cancellationToken: CancellationToken.None));
         Assert.Contains("not allowed", ex.Message);
+    }
+
+    [Fact]
+    public async Task FetchDistributionToken_WithExpiresIn_SetsExpiresAtFromClock()
+    {
+        // Arrange
+        var realm = "https://example.registry/token";
+        var service = "test_service";
+        var scopes = new List<string> { "repository:repo:pull" };
+        var now = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        HttpResponseMessage MockHttpRequestHandler(HttpRequestMessage req, CancellationToken ct = default)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"access_token\":\"tok\",\"expires_in\":600}"),
+                RequestMessage = req
+            };
+
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object))
+        {
+            TimeProvider = new FixedTimeProvider(now)
+        };
+
+        // Act
+        var result = await client.FetchDistributionTokenAsync(
+            realm, service, scopes, null, null, CancellationToken.None);
+
+        // Assert — expires_at = now + expires_in (no issued_at supplied).
+        Assert.Equal("tok", result.Token);
+        Assert.Equal(now.AddSeconds(600), result.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task FetchDistributionToken_WithIssuedAt_ComputesExpiresAtFromIssuedAt()
+    {
+        // Arrange
+        var realm = "https://example.registry/token";
+        var service = "test_service";
+        var scopes = new List<string> { "repository:repo:pull" };
+        var issuedAt = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+        HttpResponseMessage MockHttpRequestHandler(HttpRequestMessage req, CancellationToken ct = default)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"access_token\":\"tok\",\"expires_in\":600,\"issued_at\":\"2024-06-01T12:00:00Z\"}"),
+                RequestMessage = req
+            };
+
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object))
+        {
+            // A far-off clock proves issued_at (not the clock) is used when present.
+            TimeProvider = new FixedTimeProvider(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero))
+        };
+
+        // Act
+        var result = await client.FetchDistributionTokenAsync(
+            realm, service, scopes, null, null, CancellationToken.None);
+
+        // Assert — expires_at = issued_at + expires_in.
+        Assert.Equal(issuedAt.AddSeconds(600), result.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task FetchDistributionToken_WithoutExpiresIn_ExpiresAtIsNull()
+    {
+        // Arrange
+        var realm = "https://example.registry/token";
+        var service = "test_service";
+        var scopes = new List<string> { "repository:repo:pull" };
+
+        HttpResponseMessage MockHttpRequestHandler(HttpRequestMessage req, CancellationToken ct = default)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"access_token\":\"tok\"}"),
+                RequestMessage = req
+            };
+
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object));
+
+        // Act
+        var result = await client.FetchDistributionTokenAsync(
+            realm, service, scopes, null, null, CancellationToken.None);
+
+        // Assert — no server-declared expiry.
+        Assert.Null(result.ExpiresAt);
     }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/JwtExpiryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/JwtExpiryTest.cs
@@ -1,0 +1,67 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using OrasProject.Oras.Registry.Remote.Auth;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+public class JwtExpiryTest
+{
+    [Fact]
+    public void TryGetExpiration_ValidJwtWithExp_ReturnsExpiration()
+    {
+        var unix = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds();
+        var token = AuthTestHelpers.CreateJwt(unix);
+
+        var ok = JwtExpiry.TryGetExpiration(token, out var expiration);
+
+        Assert.True(ok);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(unix), expiration);
+    }
+
+    [Fact]
+    public void TryGetExpiration_JwtWithoutExpClaim_ReturnsFalse()
+    {
+        var token = AuthTestHelpers.CreateJwt(null);
+
+        Assert.False(JwtExpiry.TryGetExpiration(token, out var expiration));
+        Assert.Equal(default, expiration);
+    }
+
+    [Theory]
+    [InlineData("opaque-token-value")]
+    [InlineData("only.two")]
+    [InlineData("not-a-jwt")]
+    public void TryGetExpiration_OpaqueOrMalformedToken_ReturnsFalse(string token)
+    {
+        Assert.False(JwtExpiry.TryGetExpiration(token, out _));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryGetExpiration_EmptyOrWhitespace_ReturnsFalse(string token)
+    {
+        Assert.False(JwtExpiry.TryGetExpiration(token, out _));
+    }
+
+    [Fact]
+    public void TryGetExpiration_OversizedToken_ReturnsFalse()
+    {
+        var token = new string('a', 70 * 1024);
+
+        Assert.False(JwtExpiry.TryGetExpiration(token, out _));
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/TokenExpiryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/TokenExpiryTest.cs
@@ -1,0 +1,59 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using OrasProject.Oras.Registry.Remote.Auth;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+public class TokenExpiryTest
+{
+    private static readonly DateTimeOffset _now = new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Resolve_ServerExpiresAtProvided_TakesPrecedenceOverJwt()
+    {
+        var serverExpiresAt = _now.AddMinutes(10);
+        // The token carries a different (earlier) exp to prove the server value wins.
+        var token = AuthTestHelpers.CreateJwt(_now.AddMinutes(1).ToUnixTimeSeconds());
+
+        var result = TokenExpiry.Resolve(
+            token, serverExpiresAt, new FixedTimeProvider(_now), TimeSpan.FromMinutes(5));
+
+        Assert.Equal(serverExpiresAt, result);
+    }
+
+    [Fact]
+    public void Resolve_NoServerExpiry_UsesJwtExp()
+    {
+        var unix = _now.AddMinutes(30).ToUnixTimeSeconds();
+        var token = AuthTestHelpers.CreateJwt(unix);
+
+        var result = TokenExpiry.Resolve(
+            token, null, new FixedTimeProvider(_now), TimeSpan.FromMinutes(5));
+
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(unix), result);
+    }
+
+    [Fact]
+    public void Resolve_NoServerExpiryAndOpaqueToken_UsesDefaultTtl()
+    {
+        var defaultTtl = TimeSpan.FromMinutes(5);
+
+        var result = TokenExpiry.Resolve(
+            "opaque-token", null, new FixedTimeProvider(_now), defaultTtl);
+
+        Assert.Equal(_now + defaultTtl, result);
+    }
+}

--- a/tests/OrasProject.Oras.Tests/examples/MultiTenantAuthCacheExamples.cs
+++ b/tests/OrasProject.Oras.Tests/examples/MultiTenantAuthCacheExamples.cs
@@ -160,9 +160,9 @@ public class MultiTenantAuthCacheExamples
 
         // Set tokens for different customers
         cache.SetCache(
-            registry, Challenge.Scheme.Bearer, scopeKey, "token-for-customer-A", "customer-A");
+            registry, Challenge.Scheme.Bearer, scopeKey, "token-for-customer-A", partitionId: "customer-A");
         cache.SetCache(
-            registry, Challenge.Scheme.Bearer, scopeKey, "token-for-customer-B", "customer-B");
+            registry, Challenge.Scheme.Bearer, scopeKey, "token-for-customer-B", partitionId: "customer-B");
 
         // Each customer has isolated token cache
         cache.TryGetToken(


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — do not merge yet.** This PR is **stacked on top of #406** (pluggable IAuthChallengeHandler) and uses `pr/pluggable-auth-challenge-handler` as its base so the diff shows only the TTL changes. It must wait until **#406 merges first**; afterward it can be retargeted to `main`.

## What

Adds a time-to-live (TTL) to cached registry auth tokens. Each cached token's expiry is resolved in a fixed order:

1. **Server-declared expiry** — parsed from the token endpoint response (`expires_in`, plus optional `issued_at`).
2. **JWT `exp` claim** — read via `System.IdentityModel.Tokens.Jwt` **without signature validation** (opaque / non-JWT tokens fall through safely).
3. **Default TTL** — 5 minutes (`Client.DefaultTokenExpiry`).

## How

- New types: `TokenResult`, `JwtExpiry` (safe, size-bounded `exp` extraction), `TokenExpiry` (the ordering resolver).
- `Cache` stores each token as its own `IMemoryCache` entry with `AbsoluteExpiration`, so expiry eviction is native; the scheme is a separate entry so token expiry never forces a re-challenge.
- `FetchDistributionTokenAsync` / `FetchOauth2TokenAsync` now parse `expires_in` / `issued_at`; the expiry is threaded through `AuthChallengeResolution.ExpiresAt` and resolved centrally in `Client`.

## Tests

- 17 new tests: JWT parsing, resolver ordering, cache expiry + scheme survival, `expires_in` / `issued_at` parsing. Full suite green locally (one pre-existing Windows-only realm-URL test is unrelated).

## Notes

- New dependency: `System.IdentityModel.Tokens.Jwt`.
- Public API additions: `ICache.SetCache` gains an optional `expiresAt`; a few auth fetch methods now return `TokenResult` instead of `string`.

_The full implementation plan will be posted as a follow-up comment._
