### PR TITLE
feat(auth): prototype IRegistryAuthenticator (composable auth seam)

### DIFF
--- a/docs/auth/realm-validation.md
+++ b/docs/auth/realm-validation.md
@@ -1,0 +1,119 @@
+# Realm Validation
+
+When a registry responds to a request with a `401 Unauthorized` and a
+`WWW-Authenticate: Bearer` challenge, that challenge contains a `realm` — the URL
+of the token endpoint the client should contact to obtain a bearer token. The
+`realm` is **supplied by the (potentially untrusted) registry**, so before the
+client sends credentials there, it validates the realm with an
+[`IRealmValidator`](../../src/OrasProject.Oras/Registry/Remote/Auth/IRealmValidator.cs).
+
+This guards against a malicious or compromised registry directing the client to
+send credentials/tokens to an attacker-controlled host.
+
+## Default behavior: least-permissive
+
+`Client` uses [`DefaultRealmValidator`](../../src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs)
+unless you supply your own. It applies these rules, in order:
+
+1. Reject non-HTTP(S) schemes.
+2. Reject `http` unless `AllowInsecureHttp` is enabled.
+3. Reject realm URLs containing userinfo (e.g. `https://user:pass@host/...`).
+4. **Allow** if the realm host matches the registry host (same host, port-aware).
+5. **Allow** if the realm host is in `TrustedRealmHosts` and the realm is on the scheme-default port.
+6. Otherwise **deny**.
+
+> [!IMPORTANT]
+> `TrustedRealmHosts` is **empty by default**. Out of the box, only realms on the
+> **same host** as the registry are allowed (rule 4). The SDK is intentionally
+> host-agnostic and does **not** bake in trust for any specific registry.
+
+Many public registries serve their token endpoint from a **different** host than
+the registry itself, for example:
+
+| Registry            | Auth realm host     |
+| ------------------- | ------------------- |
+| `registry-1.docker.io` (Docker Hub) | `auth.docker.io`    |
+| `registry.gitlab.com` (GitLab)      | `gitlab.com`        |
+| `nvcr.io` (NVIDIA NGC)              | `authn.nvidia.com`  |
+
+Because these auth hosts differ from the registry host, they are **rejected by
+default** and must be opted into explicitly (see below).
+
+## Opting in to cross-host auth realms
+
+Add the realm's auth host(s) to `TrustedRealmHosts`:
+
+```csharp
+using System.Collections.Immutable;
+using OrasProject.Oras.Registry.Remote.Auth;
+
+var validator = new DefaultRealmValidator
+{
+    TrustedRealmHosts = ImmutableHashSet.Create(
+        "auth.docker.io",       // Docker Hub (registry-1.docker.io)
+        "gitlab.com",           // GitLab (registry.gitlab.com)
+        "authn.nvidia.com",     // NVIDIA NGC (nvcr.io)
+        "login.mycompany.com")  // your enterprise auth endpoint
+};
+
+var client = new Client(httpClient)
+{
+    RealmValidator = validator
+};
+```
+
+`TrustedRealmHosts` accepts any `IReadOnlySet<string>`. Prefer an
+[`ImmutableHashSet<string>`](https://learn.microsoft.com/dotnet/api/system.collections.immutable.immutablehashset-1):
+the trusted-host allowlist is fixed configuration, so an immutable set makes
+that intent explicit and is safe to share across clients. The validator also
+snapshots the set on assignment, so later mutations to a mutable collection you
+passed in have no effect.
+
+Hostnames are normalized (lowercased, trailing dots stripped) and the match is
+case-insensitive. A trusted host is still required to be on the default port for
+its scheme and to pass the scheme/userinfo checks above.
+
+## Local development over HTTP
+
+For a registry running on `localhost` without TLS, enable `AllowInsecureHttp`:
+
+```csharp
+var validator = new DefaultRealmValidator { AllowInsecureHttp = true };
+var client = new Client(httpClient) { RealmValidator = validator };
+```
+
+This only relaxes the scheme check; the same-host / trusted-host rules still apply.
+
+## Custom validators
+
+For full control (for example, allowing any auth host within a corporate domain
+suffix), implement `IRealmValidator` and assign it to `Client.RealmValidator`:
+
+```csharp
+public class CorporateDomainRealmValidator : IRealmValidator
+{
+    private readonly string _allowedSuffix;
+
+    public CorporateDomainRealmValidator(string allowedDomainSuffix)
+        => _allowedSuffix = allowedDomainSuffix.ToLowerInvariant();
+
+    public Task<bool> IsRealmAllowedAsync(
+        Uri registryUri, Uri realmUri, CancellationToken cancellationToken = default)
+    {
+        if (!realmUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(false);
+        }
+
+        var host = realmUri.Host.ToLowerInvariant();
+        return Task.FromResult(host.EndsWith(_allowedSuffix, StringComparison.Ordinal));
+    }
+}
+```
+
+## Runnable examples
+
+See
+[`examples/OrasProject.Oras.Examples.RealmValidation`](../../examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs)
+for runnable versions of the snippets above, including
+`CreateClientTrustingWellKnownPublicRegistries`.

--- a/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #region Usage
+using System.Collections.Immutable;
 using OrasProject.Oras.Registry.Remote.Auth;
 
 namespace OrasProject.Oras.Examples.RealmValidation;
@@ -29,18 +30,45 @@ public static class RealmValidationExamples
     {
         ArgumentNullException.ThrowIfNull(httpClient);
 
-        // DefaultRealmValidator ships with auth.docker.io and
-        // gitlab.com pre-configured. You can override the trusted
-        // hosts to include your organization's auth endpoints.
+        // DefaultRealmValidator ships with NO trusted hosts: by default
+        // only realms on the same host as the registry are allowed. To
+        // trust a registry whose auth realm lives on a different host,
+        // list those auth hosts explicitly — for example your
+        // organization's auth endpoints.
+        //
+        // Prefer an ImmutableHashSet<string> here: the trusted-host
+        // allowlist is fixed configuration, and an immutable set makes
+        // that intent explicit and is safe to share across clients.
         var validator = new DefaultRealmValidator
         {
-            TrustedRealmHosts = new HashSet<string>
-            {
-                "auth.docker.io",
-                "gitlab.com",
+            TrustedRealmHosts = ImmutableHashSet.Create(
                 "login.mycompany.com",
-                "auth.internal.example.com",
-            }
+                "auth.internal.example.com")
+        };
+
+        return new Client(httpClient)
+        {
+            RealmValidator = validator
+        };
+    }
+
+    /// <summary>
+    /// Opts into well-known public registries whose auth realm host
+    /// differs from the registry host (Docker Hub, GitLab, NVIDIA NGC).
+    /// These are intentionally NOT trusted by default — the SDK is
+    /// host-agnostic — so callers enable them explicitly.
+    /// </summary>
+    public static Client CreateClientTrustingWellKnownPublicRegistries(
+        HttpClient httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = ImmutableHashSet.Create(
+                "auth.docker.io",    // Docker Hub (registry-1.docker.io)
+                "gitlab.com",        // GitLab (registry.gitlab.com)
+                "authn.nvidia.com")  // NVIDIA NGC (nvcr.io)
         };
 
         return new Client(httpClient)

--- a/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallenge.cs
@@ -1,0 +1,69 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Immutable description of a 401 (Unauthorized) exchange, handed to the standard-resolution and
+/// recovery hooks of <see cref="DefaultRegistryAuthenticator"/>. It is plain data — no client
+/// references, no capabilities. The authenticator supplies I/O via the injected
+/// <see cref="RegistryTransport"/> instead.
+/// </summary>
+public sealed class AuthChallenge
+{
+    /// <summary>Initializes a new instance.</summary>
+    public AuthChallenge(
+        HttpRequestMessage originalRequest,
+        HttpResponseMessage unauthorizedResponse,
+        string host,
+        IReadOnlyList<string> requestedScopes,
+        bool attachedCachedToken,
+        string? partitionId)
+    {
+        OriginalRequest = originalRequest;
+        UnauthorizedResponse = unauthorizedResponse;
+        Host = host;
+        RequestedScopes = requestedScopes;
+        AttachedCachedToken = attachedCachedToken;
+        PartitionId = partitionId;
+    }
+
+    /// <summary>The original request (no <c>Authorization</c> header set).</summary>
+    public HttpRequestMessage OriginalRequest { get; }
+
+    /// <summary>The 401 response, including its <c>WWW-Authenticate</c> challenge.</summary>
+    public HttpResponseMessage UnauthorizedResponse { get; }
+
+    /// <summary>The registry authority (host[:port]).</summary>
+    public string Host { get; }
+
+    /// <summary>The scopes computed for <see cref="Host"/> before this challenge.</summary>
+    public IReadOnlyList<string> RequestedScopes { get; }
+
+    /// <summary>Whether the failed attempt carried a cached token (a stale-token-rejection hint).</summary>
+    public bool AttachedCachedToken { get; }
+
+    /// <summary>The cache partition identifier for the request, if any.</summary>
+    public string? PartitionId { get; }
+
+    /// <summary>The cache scope key the failed attempt used.</summary>
+    public string AttemptedKey => string.Join(" ", RequestedScopes);
+
+    /// <summary>Whether the original request can be safely re-sent (an idempotent GET/HEAD).</summary>
+    public bool CanReplay =>
+        OriginalRequest.Method == HttpMethod.Get ||
+        OriginalRequest.Method == HttpMethod.Head;
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/AuthContext.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/AuthContext.cs
@@ -1,0 +1,31 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// The per-request context an <see cref="IRegistryAuthenticator"/> needs beyond the request itself.
+/// This is plain data — it carries no client references or capabilities.
+/// </summary>
+public sealed class AuthContext
+{
+    /// <summary>
+    /// Optional cache partition identifier, isolating cached tokens per credential set.
+    /// </summary>
+    public string? PartitionId { get; init; }
+
+    /// <summary>
+    /// Whether the request (and its auth retries) should follow redirects.
+    /// </summary>
+    public bool AllowAutoRedirect { get; init; } = true;
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -30,8 +30,10 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// <item>Reject non-HTTP(S) schemes.</item>
 /// <item>Reject HTTP unless <see cref="AllowInsecureHttp"/> is true.</item>
 /// <item>Reject realm URLs containing userinfo.</item>
-/// <item>Allow if realm host matches the registry host (same host).</item>
-/// <item>Allow if realm host is in <see cref="TrustedRealmHosts"/>.</item>
+/// <item>Allow if the realm host and effective port match the
+/// registry (same host and port).</item>
+/// <item>Allow if the realm host is in <see cref="TrustedRealmHosts"/>
+/// (empty by default) and the realm is on the scheme-default port.</item>
 /// <item>Default deny.</item>
 /// </list>
 /// </remarks>
@@ -44,21 +46,27 @@ public sealed class DefaultRealmValidator : IRealmValidator
     public bool AllowInsecureHttp { get; init; }
 
     /// <summary>
-    /// Explicit set of trusted realm hostnames (case-insensitive).
-    /// Realms matching these hosts are allowed after basic URI safety
-    /// checks (scheme policy and userinfo rejection).
+    /// Explicit set of trusted realm hostnames (case-insensitive) whose
+    /// auth realm host differs from the registry host. Realms matching
+    /// these hosts are allowed after basic URI safety checks (scheme
+    /// policy and userinfo rejection).
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Pre-populated with well-known registries whose auth realm
-    /// host differs from the registry host:
+    /// <b>Empty by default.</b> The validator ships with no trusted
+    /// hosts, so out of the box only realms on the <em>same host</em>
+    /// (and effective port) as the registry are allowed. The SDK is
+    /// intentionally host-agnostic and does not bake in trust for any
+    /// specific registry.
     /// </para>
-    /// <list type="bullet">
-    /// <item><c>auth.docker.io</c> — Docker Hub
-    /// (registry: registry-1.docker.io)</item>
-    /// <item><c>gitlab.com</c> — GitLab Container Registry
-    /// (registry: registry.gitlab.com)</item>
-    /// </list>
+    /// <para>
+    /// To allow a registry whose auth realm lives on a different host
+    /// (for example Docker Hub's <c>auth.docker.io</c>, GitLab's
+    /// <c>gitlab.com</c>, or NVIDIA NGC's <c>authn.nvidia.com</c>),
+    /// configure this set explicitly or supply a custom
+    /// <see cref="IRealmValidator"/>. See the realm-validation examples
+    /// and <c>docs/auth/realm-validation.md</c>.
+    /// </para>
     /// <para>
     /// Values are normalized (lowercased, trailing dots stripped)
     /// and frozen on assignment. Mutations to the original
@@ -75,10 +83,7 @@ public sealed class DefaultRealmValidator : IRealmValidator
             .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
-    private IReadOnlySet<string> _trustedRealmHosts =
-        FrozenSet.ToFrozenSet(
-            new[] { "auth.docker.io", "gitlab.com" },
-            StringComparer.OrdinalIgnoreCase);
+    private IReadOnlySet<string> _trustedRealmHosts = FrozenSet<string>.Empty;
 
     /// <inheritdoc/>
     public Task<bool> IsRealmAllowedAsync(

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRegistryAuthenticator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRegistryAuthenticator.cs
@@ -1,0 +1,471 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Caching.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Security.Authentication;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// The default <see cref="IRegistryAuthenticator"/>: implements the standard OCI distribution
+/// authentication loop (attach cached token, send, and on 401 resolve Basic/Bearer, validate the
+/// realm, fetch a token, cache it, and retry). It is fully self-contained — it holds its own
+/// collaborators and uses only the injected <see cref="RegistryTransport"/> for I/O, so it never
+/// touches a <see cref="Client"/> and is unit-testable with a fake transport.
+/// </summary>
+/// <remarks>
+/// This is a design prototype for issue #405. The token-endpoint fetch mirrors <see cref="Client"/>'s
+/// existing logic but drives it through the transport; in a full change that logic would move here
+/// rather than being duplicated. Non-conformant-registry recovery is a subclass that overrides
+/// <see cref="AuthenticateAsync"/> and reuses the protected helpers below — see the tests.
+/// </remarks>
+public class DefaultRegistryAuthenticator : IRegistryAuthenticator
+{
+    private const string _defaultClientId = "oras-dotnet";
+
+    private static readonly Lazy<IMemoryCache> _sharedMemoryCache =
+        new(() => new MemoryCache(new MemoryCacheOptions { SizeLimit = 1024 }),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private ICache? _cache;
+
+    /// <summary>The token cache. Defaults to a shared in-memory cache.</summary>
+    public ICache Cache
+    {
+        get => _cache ??= new Cache(_sharedMemoryCache.Value);
+        init => _cache = value;
+    }
+
+    /// <summary>The scope manager used to compute request scopes.</summary>
+    public ScopeManager ScopeManager { get; init; } = new();
+
+    /// <summary>Validates realm URLs before credentials are sent to them.</summary>
+    public IRealmValidator RealmValidator { get; init; } = new DefaultRealmValidator();
+
+    /// <summary>Optional credential provider.</summary>
+    public ICredentialProvider? CredentialProvider { get; init; }
+
+    /// <summary>Optional pre-resolved access-token provider.</summary>
+    public IAccessTokenProvider? AccessTokenProvider { get; init; }
+
+    /// <summary>Client id used for OAuth2 token requests.</summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>Whether to force OAuth2 (password grant) for username/password credentials.</summary>
+    public bool ForceAttemptOAuth2 { get; init; }
+
+    /// <inheritdoc />
+    public async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        AuthContext context,
+        RegistryTransport transport,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(transport);
+
+        if (request.Headers.Authorization != null)
+        {
+            return await transport(request, context.AllowAutoRedirect, cancellationToken).ConfigureAwait(false);
+        }
+
+        var host = request.RequestUri?.Authority
+            ?? throw new ArgumentException("Request URI or its authority is null.", nameof(request));
+        var requestedScopes = ScopeManager.GetScopesStringForHost(host);
+        var attemptedKey = string.Join(" ", requestedScopes);
+
+        var attempt = await request.CloneAsync(rewindContent: false, cancellationToken).ConfigureAwait(false);
+        var attachedCachedToken = TryAttachCachedToken(attempt, host, attemptedKey, context.PartitionId);
+
+        var response = await transport(attempt, context.AllowAutoRedirect, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode != HttpStatusCode.Unauthorized)
+        {
+            return response;
+        }
+
+        var challenge = new AuthChallenge(
+            request, response, host, requestedScopes, attachedCachedToken, context.PartitionId);
+        try
+        {
+            var authenticated = await AuthenticateAsync(challenge, context, transport, cancellationToken)
+                .ConfigureAwait(false);
+            if (authenticated == null)
+            {
+                // Could not resolve; hand the original 401 back to the caller.
+                return response;
+            }
+
+            response.Dispose();
+            return authenticated;
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// The single overridable policy: turn a 401 into an authenticated response, or return
+    /// <c>null</c> to give up (the caller returns the original 401). The base implementation parses
+    /// the challenge and delegates to <see cref="AuthenticateFromChallengeAsync"/>. Override this to
+    /// add recovery for non-conformant registries — call <c>base</c>, and on <c>null</c> probe via
+    /// <see cref="SendWithoutAuthorizationAsync"/> and re-resolve.
+    /// </summary>
+    protected virtual Task<HttpResponseMessage?> AuthenticateAsync(
+        AuthChallenge challenge,
+        AuthContext context,
+        RegistryTransport transport,
+        CancellationToken cancellationToken)
+    {
+        var (scheme, parameters) = ParseChallengeSafe(challenge.UnauthorizedResponse);
+        return AuthenticateFromChallengeAsync(challenge, scheme, parameters, context, transport, cancellationToken);
+    }
+
+    /// <summary>
+    /// Standard resolution for a parsed challenge, returning the authenticated response, or
+    /// <c>null</c> for an UNUSABLE challenge (no/unknown scheme, or a missing / invalid / disallowed
+    /// realm). A credential or token-endpoint failure behind an allowed realm still throws, so a
+    /// recovery override can safely treat <c>null</c> as "try to recover" without masking real
+    /// credential errors. Because the unit returns a response, the non-throwing composition is
+    /// natural — no separate failure-kind result type is needed.
+    /// </summary>
+    protected async Task<HttpResponseMessage?> AuthenticateFromChallengeAsync(
+        AuthChallenge challenge,
+        Challenge.Scheme scheme,
+        IReadOnlyDictionary<string, string>? parameters,
+        AuthContext context,
+        RegistryTransport transport,
+        CancellationToken cancellationToken)
+    {
+        switch (scheme)
+        {
+            case Challenge.Scheme.Basic:
+                {
+                    var basic = await FetchBasicAsync(challenge.Host, cancellationToken).ConfigureAwait(false);
+                    Cache.SetCache(challenge.Host, Challenge.Scheme.Basic, string.Empty, basic, challenge.PartitionId);
+                    return await RetryAsync(challenge, context, transport, "Basic", basic, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            case Challenge.Scheme.Bearer:
+                {
+                    if (parameters == null)
+                    {
+                        return null;
+                    }
+
+                    var (scopes, newKey) = MergeChallengeScopes(challenge.Host, parameters.GetValueOrDefault("scope"));
+
+                    // Scope-changed cache shortcut: a cached token for the challenged scope is tried
+                    // before acquiring a new one. Because the unit returns a response, the
+                    // try-then-fall-through is expressed directly (no lossy "resolution").
+                    if (newKey != challenge.AttemptedKey &&
+                        Cache.TryGetToken(challenge.Host, Challenge.Scheme.Bearer, newKey, out var cachedToken, challenge.PartitionId))
+                    {
+                        var shortcut = await RetryAsync(challenge, context, transport, "Bearer", cachedToken, cancellationToken)
+                            .ConfigureAwait(false);
+                        if (shortcut.StatusCode != HttpStatusCode.Unauthorized)
+                        {
+                            return shortcut;
+                        }
+
+                        shortcut.Dispose();
+                    }
+
+                    if (!parameters.TryGetValue("realm", out var realm) ||
+                        !Uri.TryCreate(realm, UriKind.Absolute, out var realmUri))
+                    {
+                        return null;
+                    }
+
+                    if (!await RealmValidator
+                        .IsRealmAllowedAsync(challenge.OriginalRequest.RequestUri!, realmUri, cancellationToken)
+                        .ConfigureAwait(false))
+                    {
+                        return null;
+                    }
+
+                    parameters.TryGetValue("service", out var service);
+                    var token = await FetchBearerAsync(
+                        challenge.Host, realm, service ?? string.Empty, scopes, transport, cancellationToken)
+                        .ConfigureAwait(false);
+                    Cache.SetCache(challenge.Host, Challenge.Scheme.Bearer, newKey, token, challenge.PartitionId);
+                    return await RetryAsync(challenge, context, transport, "Bearer", token, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Re-sends the original request with no <c>Authorization</c> header to elicit a fresh challenge.
+    /// The recovery primitive — it is just a call to the transport, so no client façade is needed.
+    /// The returned response is owned by the caller and must be disposed.
+    /// </summary>
+    protected static async Task<HttpResponseMessage> SendWithoutAuthorizationAsync(
+        AuthChallenge challenge,
+        AuthContext context,
+        RegistryTransport transport,
+        CancellationToken cancellationToken)
+    {
+        var cold = await challenge.OriginalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+        cold.Headers.Authorization = null;
+        return await transport(cold, context.AllowAutoRedirect, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Parses the challenge, degrading a malformed one to <see cref="Challenge.Scheme.Unknown"/>.</summary>
+    protected static (Challenge.Scheme Scheme, IReadOnlyDictionary<string, string>? Parameters) ParseChallengeSafe(
+        HttpResponseMessage response)
+    {
+        try
+        {
+            return Challenge.ParseChallenge(response.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
+        {
+            return (Challenge.Scheme.Unknown, null);
+        }
+    }
+
+    private bool TryAttachCachedToken(HttpRequestMessage request, string host, string attemptedKey, string? partitionId)
+    {
+        if (!Cache.TryGetScheme(host, out var scheme, partitionId))
+        {
+            return false;
+        }
+
+        switch (scheme)
+        {
+            case Challenge.Scheme.Basic
+                when Cache.TryGetToken(host, scheme, string.Empty, out var basic, partitionId):
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", basic);
+                return true;
+            case Challenge.Scheme.Bearer
+                when Cache.TryGetToken(host, scheme, attemptedKey, out var bearer, partitionId):
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private (IReadOnlyList<string> Scopes, string CacheKey) MergeChallengeScopes(string host, string? scopeParameter)
+    {
+        var scopes = new SortedSet<Scope>(ScopeManager.GetScopesForHost(host));
+        if (!string.IsNullOrEmpty(scopeParameter))
+        {
+            foreach (var scopeStr in scopeParameter.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (Scope.TryParse(scopeStr, out var scope))
+                {
+                    Scope.AddOrMergeScope(scopes, scope);
+                }
+            }
+        }
+
+        return (scopes.Select(scope => scope.ToString()).ToList(), string.Join(" ", scopes));
+    }
+
+    private static async Task<HttpResponseMessage> RetryAsync(
+        AuthChallenge challenge,
+        AuthContext context,
+        RegistryTransport transport,
+        string scheme,
+        string token,
+        CancellationToken cancellationToken)
+    {
+        var retry = await challenge.OriginalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+        retry.Headers.Authorization = new AuthenticationHeaderValue(scheme, token);
+        return await transport(retry, context.AllowAutoRedirect, cancellationToken).ConfigureAwait(false);
+    }
+
+    private Task<Credential> ResolveCredentialAsync(string host, CancellationToken cancellationToken)
+        => CredentialProvider == null
+            ? Task.FromResult(CredentialExtensions.EmptyCredential)
+            : CredentialProvider.ResolveCredentialAsync(host, cancellationToken);
+
+    private async Task<string> FetchBasicAsync(string host, CancellationToken cancellationToken)
+    {
+        var credential = await ResolveCredentialAsync(host, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(credential.Username) || string.IsNullOrWhiteSpace(credential.Password))
+        {
+            throw new AuthenticationException("Missing username or password for basic authentication.");
+        }
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes($"{credential.Username}:{credential.Password}"));
+    }
+
+    private async Task<string> FetchBearerAsync(
+        string host,
+        string realm,
+        string service,
+        IReadOnlyList<string> scopes,
+        RegistryTransport transport,
+        CancellationToken cancellationToken)
+    {
+        if (AccessTokenProvider != null)
+        {
+            var accessToken = await AccessTokenProvider
+                .ResolveAccessTokenAsync(host, realm, service, scopes, forceRefresh: true, cancellationToken)
+                .ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(accessToken))
+            {
+                return accessToken;
+            }
+        }
+
+        var credential = await ResolveCredentialAsync(host, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(credential.AccessToken))
+        {
+            return credential.AccessToken;
+        }
+
+        if (credential.IsEmpty() ||
+            (string.IsNullOrWhiteSpace(credential.RefreshToken) && !ForceAttemptOAuth2))
+        {
+            return await FetchDistributionTokenAsync(
+                realm, service, scopes, credential.Username, credential.Password, transport, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return await FetchOAuth2TokenAsync(realm, service, scopes, credential, transport, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<string> FetchDistributionTokenAsync(
+        string realm,
+        string service,
+        IReadOnlyList<string> scopes,
+        string? username,
+        string? password,
+        RegistryTransport transport,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, realm);
+        if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                "Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}")));
+        }
+
+        var query = new List<KeyValuePair<string, string>>();
+        if (!string.IsNullOrWhiteSpace(service))
+        {
+            query.Add(new KeyValuePair<string, string>("service", service));
+        }
+
+        foreach (var scope in scopes)
+        {
+            query.Add(new KeyValuePair<string, string>("scope", scope));
+        }
+
+        request.RequestUri = new UriBuilder(request.RequestUri!)
+        {
+            Query = string.Join("&", query.Select(p => $"{Uri.EscapeDataString(p.Key)}={Uri.EscapeDataString(p.Value)}")),
+        }.Uri;
+
+        using var response = await transport(request, true, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            throw await response.ParseErrorResponseAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(body);
+        if (doc.RootElement.TryGetProperty("access_token", out var accessToken) &&
+            !string.IsNullOrWhiteSpace(accessToken.GetString()))
+        {
+            return accessToken.GetString()!;
+        }
+
+        if (doc.RootElement.TryGetProperty("token", out var token) &&
+            !string.IsNullOrWhiteSpace(token.GetString()))
+        {
+            return token.GetString()!;
+        }
+
+        throw new AuthenticationException("Both AccessToken and Token are empty or missing");
+    }
+
+    private async Task<string> FetchOAuth2TokenAsync(
+        string realm,
+        string service,
+        IReadOnlyList<string> scopes,
+        Credential credential,
+        RegistryTransport transport,
+        CancellationToken cancellationToken)
+    {
+        var form = new Dictionary<string, string>
+        {
+            ["client_id"] = string.IsNullOrEmpty(ClientId) ? _defaultClientId : ClientId,
+        };
+        if (!string.IsNullOrWhiteSpace(service))
+        {
+            form["service"] = service;
+        }
+
+        if (!string.IsNullOrEmpty(credential.RefreshToken))
+        {
+            form["grant_type"] = "refresh_token";
+            form["refresh_token"] = credential.RefreshToken;
+        }
+        else if (!string.IsNullOrEmpty(credential.Username) && !string.IsNullOrEmpty(credential.Password))
+        {
+            form["grant_type"] = "password";
+            form["username"] = credential.Username;
+            form["password"] = credential.Password;
+        }
+        else
+        {
+            throw new AuthenticationException("missing username or password for bearer auth");
+        }
+
+        if (scopes.Count > 0)
+        {
+            form["scope"] = string.Join(" ", scopes);
+        }
+
+        using var content = new FormUrlEncodedContent(form);
+        using var request = new HttpRequestMessage(HttpMethod.Post, realm) { Content = content };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Application.FormUrlEncoded);
+
+        using var response = await transport(request, true, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            throw await response.ParseErrorResponseAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(body);
+        if (doc.RootElement.TryGetProperty("access_token", out var accessToken) &&
+            !string.IsNullOrEmpty(accessToken.ToString()))
+        {
+            return accessToken.ToString();
+        }
+
+        throw new AuthenticationException("AccessToken is empty or missing");
+    }
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRegistryAuthenticator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRegistryAuthenticator.cs
@@ -44,16 +44,15 @@ public class DefaultRegistryAuthenticator : IRegistryAuthenticator
 {
     private const string _defaultClientId = "oras-dotnet";
 
-    private static readonly Lazy<IMemoryCache> _sharedMemoryCache =
-        new(() => new MemoryCache(new MemoryCacheOptions { SizeLimit = 1024 }),
-            LazyThreadSafetyMode.ExecutionAndPublication);
+    private ICache _cache = new Cache(new MemoryCache(new MemoryCacheOptions { SizeLimit = 1024 }));
 
-    private ICache? _cache;
-
-    /// <summary>The token cache. Defaults to a shared in-memory cache.</summary>
+    /// <summary>
+    /// The token cache. Defaults to a cache private to this authenticator instance, so tokens do not
+    /// bleed across instances; inject a shared <see cref="ICache"/> to share them deliberately.
+    /// </summary>
     public ICache Cache
     {
-        get => _cache ??= new Cache(_sharedMemoryCache.Value);
+        get => _cache;
         init => _cache = value;
     }
 

--- a/src/OrasProject.Oras/Registry/Remote/Auth/IRegistryAuthenticator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/IRegistryAuthenticator.cs
@@ -1,0 +1,54 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Produces an authenticated response for a registry request. This is the pluggable unit for
+/// authentication: it owns the entire attach-token → send → 401 → resolve → retry loop, so response
+/// handling lives in one place and consumers can compose or replace the whole behavior.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike a "given a 401, return a token" hook, an authenticator takes the raw request and the
+/// <see cref="RegistryTransport"/> and returns the final response. It never references a
+/// <see cref="Client"/>: the transport is its only outbound capability, so a credential-free probe
+/// is simply a call to the transport, and the whole thing is unit-testable with a fake transport.
+/// </para>
+/// <para>
+/// The default, <see cref="DefaultRegistryAuthenticator"/>, implements the standard OCI flow.
+/// Recovery for non-conformant registries is a subclass (or decorator) of the default, not a new
+/// context surface.
+/// </para>
+/// </remarks>
+public interface IRegistryAuthenticator
+{
+    /// <summary>
+    /// Sends <paramref name="request"/> through <paramref name="transport"/>, performing any
+    /// authentication handshake, and returns the resulting response.
+    /// </summary>
+    /// <param name="request">The request to authenticate and send. Must not have an <c>Authorization</c> header.</param>
+    /// <param name="context">Per-request data (partition, redirect policy).</param>
+    /// <param name="transport">The capability used to send requests (including a credential-free probe).</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The authenticated response, or the original 401 if authentication could not be resolved.</returns>
+    Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        AuthContext context,
+        RegistryTransport transport,
+        CancellationToken cancellationToken = default);
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/RegistryTransport.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/RegistryTransport.cs
@@ -1,0 +1,37 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Sends an HTTP request and returns its response, choosing whether to follow redirects. This is
+/// the only capability an <see cref="IRegistryAuthenticator"/> needs from its host — it decouples
+/// the authenticator from any particular <see cref="Client"/> or <see cref="HttpClient"/>, so a
+/// unit test can supply a fake transport and no real network or client is required.
+/// </summary>
+/// <param name="request">The request to send.</param>
+/// <param name="allowAutoRedirect">
+/// Whether redirects should be followed. Passing this per call lets the authenticator use a
+/// redirect-following transport for token endpoints and a non-following one for blob-location
+/// capture, without the two-<see cref="HttpClient"/> coupling a message-handler chain would impose.
+/// </param>
+/// <param name="cancellationToken">A token to cancel the operation.</param>
+/// <returns>The HTTP response.</returns>
+public delegate Task<HttpResponseMessage> RegistryTransport(
+    HttpRequestMessage request,
+    bool allowAutoRedirect,
+    CancellationToken cancellationToken);

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
@@ -299,25 +299,57 @@ public class DefaultRealmValidatorTest
             Realm("http://myreg.io/token")));
     }
 
-    [Fact]
-    public async Task TrustedHostNotAffectedBySchemeBlock()
+    [Theory]
+    [InlineData(
+        "https://registry-1.docker.io/v2/",
+        "https://auth.docker.io/token",
+        "auth.docker.io")]
+    [InlineData(
+        "https://registry.gitlab.com/v2/",
+        "https://gitlab.com/jwt/auth",
+        "gitlab.com")]
+    [InlineData(
+        "https://nvcr.io/v2/",
+        "https://authn.nvidia.com/token",
+        "authn.nvidia.com")]
+    public async Task WellKnownPublicRegistry_RejectedByDefault_AllowedWhenConfigured(
+        string registry, string realm, string trustedHost)
     {
-        // Docker Hub: auth.docker.io is in the default trusted
-        // list — works without explicit TrustedRealmHosts.
-        var validator = new DefaultRealmValidator();
-        Assert.True(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
-            Realm("https://auth.docker.io/token")));
+        // Default ships with no trusted hosts: well-known public
+        // registries whose auth realm is on a different host are
+        // rejected until explicitly opted in.
+        var defaultValidator = new DefaultRealmValidator();
+        Assert.False(await defaultValidator.IsRealmAllowedAsync(
+            Reg(registry), Realm(realm)));
+
+        // Opt in by configuring the realm's auth host.
+        var configured = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                trustedHost
+            }
+        };
+        Assert.True(await configured.IsRealmAllowedAsync(
+            Reg(registry), Realm(realm)));
     }
 
     [Fact]
-    public async Task GitLabRegistry_DefaultTrusted_Allowed()
+    public async Task TrustedHost_NonDefaultPort_Rejected()
     {
-        // GitLab: gitlab.com is in the default trusted list.
-        var validator = new DefaultRealmValidator();
-        Assert.True(await validator.IsRealmAllowedAsync(
-            Reg("https://registry.gitlab.com/v2/"),
-            Realm("https://gitlab.com/jwt/auth")));
+        // A configured trusted host must still be on the default port.
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://registry.example.com/v2/"),
+            Realm("https://auth.example.com:8443/token")));
     }
 
     [Fact]
@@ -452,21 +484,35 @@ public class DefaultRealmValidatorTest
     public async Task UserinfoOnTrustedHost_Rejected()
     {
         // Userinfo check fires before trusted host check.
-        var validator = new DefaultRealmValidator();
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
+            Reg("https://registry.example.com/v2/"),
             Realm(
-                "https://user@auth.docker.io/token")));
+                "https://user@auth.example.com/token")));
     }
 
     [Fact]
     public async Task HttpOnTrustedHost_RejectedByDefault()
     {
         // HTTP scheme block applies even to trusted hosts.
-        var validator = new DefaultRealmValidator();
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
-            Realm("http://auth.docker.io/token")));
+            Reg("https://registry.example.com/v2/"),
+            Realm("http://auth.example.com/token")));
     }
 
     [Fact]
@@ -483,12 +529,19 @@ public class DefaultRealmValidatorTest
     [Fact]
     public async Task SuperstringHostname_Rejected()
     {
-        // "auth.docker.io.evil.com" is NOT "auth.docker.io"
-        var validator = new DefaultRealmValidator();
+        // "auth.example.com.evil.com" is NOT "auth.example.com"
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
+            Reg("https://registry.example.com/v2/"),
             Realm(
-                "https://auth.docker.io.evil.com/tok"
+                "https://auth.example.com.evil.com/tok"
                 )));
     }
 

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/RegistryAuthenticatorPrototypeTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/RegistryAuthenticatorPrototypeTest.cs
@@ -1,0 +1,194 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using OrasProject.Oras.Registry.Remote.Auth;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+/// <summary>
+/// Prototype tests for the <see cref="IRegistryAuthenticator"/> shape (issue #405). Every test drives
+/// the authenticator through a plain <see cref="RegistryTransport"/> delegate — there is no
+/// <see cref="Client"/> and no <see cref="HttpClient"/> anywhere — which is the composability the
+/// current <c>IAuthChallengeHandler</c> design cannot offer (its context is bound to a live client).
+/// </summary>
+public class RegistryAuthenticatorPrototypeTest
+{
+    private const string _staleToken = "stale_token";
+    private const string _freshToken = "fresh_token";
+
+    // A fake transport: a pure function from request to response. No sockets, no client.
+    private static RegistryTransport Transport(Func<HttpRequestMessage, HttpResponseMessage> registry)
+        => (request, allowAutoRedirect, cancellationToken) => Task.FromResult(registry(request));
+
+    private static HttpResponseMessage Ok() => new(HttpStatusCode.OK);
+
+    private static HttpResponseMessage Token(string token) =>
+        new(HttpStatusCode.OK) { Content = new StringContent($"{{\"token\":\"{token}\"}}") };
+
+    private static HttpResponseMessage Bearer(string wwwAuthenticate)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        response.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue("Bearer", wwwAuthenticate));
+        return response;
+    }
+
+    private static HttpResponseMessage NoChallenge() => new(HttpStatusCode.Unauthorized);
+
+    [Fact]
+    public async Task Default_BearerDistributionFlow_NeedsNoClientOrHttpClient()
+    {
+        const string host = "registry.example.com";
+        HttpResponseMessage Registry(HttpRequestMessage req)
+        {
+            if (req.RequestUri!.AbsolutePath == "/token")
+            {
+                return Token(_freshToken);
+            }
+
+            return req.Headers.Authorization?.Parameter == _freshToken
+                ? Ok()
+                : Bearer($"realm=\"https://{host}/token\",service=\"{host}\"");
+        }
+
+        // Construct the authenticator directly — no Client, no HttpClient.
+        var authenticator = new DefaultRegistryAuthenticator();
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/");
+
+        var response = await authenticator.SendAsync(
+            request, new AuthContext(), Transport(Registry), CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Recovering_StaleToken401_WithNoChallenge_Recovers()
+    {
+        const string host = "registry-omits-challenge.example.com";
+        HttpResponseMessage Registry(HttpRequestMessage req)
+        {
+            if (req.RequestUri!.AbsolutePath == "/token")
+            {
+                return Token(_freshToken);
+            }
+
+            return req.Headers.Authorization?.Parameter switch
+            {
+                _freshToken => Ok(),
+                _staleToken => NoChallenge(),
+                _ => Bearer($"realm=\"https://{host}/token\",service=\"{host}\""),
+            };
+        }
+
+        var authenticator = new RecoveringRegistryAuthenticator();
+        authenticator.Cache.SetCache(host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/");
+
+        var response = await authenticator.SendAsync(
+            request, new AuthContext(), Transport(Registry), CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Recovering_StaleToken401_WithForeignRealm_Recovers()
+    {
+        const string host = "registry-foreign-realm.example.com";
+        const string foreignIdp = "idp.example.com";
+        HttpResponseMessage Registry(HttpRequestMessage req)
+        {
+            if (req.RequestUri!.AbsolutePath == "/proxy_auth")
+            {
+                return Token(_freshToken);
+            }
+
+            return req.Headers.Authorization?.Parameter switch
+            {
+                _freshToken => Ok(),
+                _staleToken => Bearer($"realm=\"https://{foreignIdp}/token\",service=\"{host}\""),
+                _ => Bearer($"realm=\"https://{host}/proxy_auth\",service=\"{host}\""),
+            };
+        }
+
+        var authenticator = new RecoveringRegistryAuthenticator();
+        authenticator.Cache.SetCache(host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/");
+
+        var response = await authenticator.SendAsync(
+            request, new AuthContext(), Transport(Registry), CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Default_StaleToken401_WithNoChallenge_DoesNotRecover()
+    {
+        const string host = "registry-omits-challenge-default.example.com";
+        HttpResponseMessage Registry(HttpRequestMessage req)
+            => req.Headers.Authorization?.Parameter == _staleToken
+                ? NoChallenge()
+                : Bearer($"realm=\"https://{host}/token\",service=\"{host}\"");
+
+        var authenticator = new DefaultRegistryAuthenticator();
+        authenticator.Cache.SetCache(host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/");
+
+        var response = await authenticator.SendAsync(
+            request, new AuthContext(), Transport(Registry), CancellationToken.None);
+
+        // The default authenticator surfaces the unusable 401 — recovery is opt-in via a subclass.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Recovery composed as a ~10-line subclass of the default authenticator: it reuses the protected
+    /// base helpers, needs no <see cref="Client"/>, and introduces no new context surface. On an
+    /// unusable challenge it probes without credentials and re-resolves from the fresh challenge.
+    /// </summary>
+    private sealed class RecoveringRegistryAuthenticator : DefaultRegistryAuthenticator
+    {
+        protected override async Task<HttpResponseMessage?> AuthenticateAsync(
+            AuthChallenge challenge,
+            AuthContext context,
+            RegistryTransport transport,
+            CancellationToken cancellationToken)
+        {
+            var response = await base.AuthenticateAsync(challenge, context, transport, cancellationToken);
+            if (response != null)
+            {
+                return response;
+            }
+
+            if (!challenge.AttachedCachedToken || !challenge.CanReplay)
+            {
+                return null;
+            }
+
+            using var cold = await SendWithoutAuthorizationAsync(challenge, context, transport, cancellationToken);
+            if (cold.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                return null;
+            }
+
+            var (scheme, parameters) = ParseChallengeSafe(cold);
+            return await AuthenticateFromChallengeAsync(
+                challenge, scheme, parameters, context, transport, cancellationToken);
+        }
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/RegistryAuthenticatorPrototypeTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/RegistryAuthenticatorPrototypeTest.cs
@@ -156,6 +156,25 @@ public class RegistryAuthenticatorPrototypeTest
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
+    [Fact]
+    public async Task Recovering_StaleToken401_AnonymousResource_ReturnsColdSuccess()
+    {
+        // A public resource whose only problem is the stale cached token: the cold, no-auth request
+        // succeeds. Recovery must return that success, not the original stale-token 401.
+        const string host = "registry-anonymous.example.com";
+        HttpResponseMessage Registry(HttpRequestMessage req)
+            => req.Headers.Authorization?.Parameter == _staleToken ? NoChallenge() : Ok();
+
+        var authenticator = new RecoveringRegistryAuthenticator();
+        authenticator.Cache.SetCache(host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/");
+
+        var response = await authenticator.SendAsync(
+            request, new AuthContext(), Transport(Registry), CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
     /// <summary>
     /// Recovery composed as a ~10-line subclass of the default authenticator: it reuses the protected
     /// base helpers, needs no <see cref="Client"/>, and introduces no new context surface. On an
@@ -180,13 +199,16 @@ public class RegistryAuthenticatorPrototypeTest
                 return null;
             }
 
-            using var cold = await SendWithoutAuthorizationAsync(challenge, context, transport, cancellationToken);
+            var cold = await SendWithoutAuthorizationAsync(challenge, context, transport, cancellationToken);
             if (cold.StatusCode != HttpStatusCode.Unauthorized)
             {
-                return null;
+                // The request succeeds without credentials (e.g. an anonymous resource whose only
+                // problem was the stale token) — hand that response back rather than the stale 401.
+                return cold;
             }
 
             var (scheme, parameters) = ParseChallengeSafe(cold);
+            cold.Dispose();
             return await AuthenticateFromChallengeAsync(
                 challenge, scheme, parameters, context, transport, cancellationToken);
         }


### PR DESCRIPTION
**Design prototype for oras-project/oras-dotnet#405 — not for merge as-is.**

Explores an alternative to the `IAuthChallengeHandler` seam (closed upstream PR oras-project/oras-dotnet#406), which coupled its context to a live `Client` and split response handling across the client and the handler.

## Idea
Model authentication as *"produce an authenticated response,"* with the raw transport injected:

```csharp
public delegate Task<HttpResponseMessage> RegistryTransport(
    HttpRequestMessage request, bool allowAutoRedirect, CancellationToken ct);

public interface IRegistryAuthenticator
{
    Task<HttpResponseMessage> SendAsync(
        HttpRequestMessage request, AuthContext context, RegistryTransport transport, CancellationToken ct);
}
```

## What it demonstrates
- **No `Client` coupling.** The authenticator's only outbound capability is the `transport` delegate. The cold probe is just a `transport` call — no façade methods.
- **Unit-testable with a fake transport.** Every test constructs `DefaultRegistryAuthenticator` and passes a `RegistryTransport` lambda — **no `Client`, no `HttpClient`**.
- **Unified response handling.** The authenticator owns attach → send → 401 → resolve → retry → cache in one place. The scope-changed cache shortcut is expressed directly (try cached token, fall through) instead of through a lossy `{ scheme, token }` resolution.
- **Non-throwing composition is natural.** Because the unit returns a response (`null` = unusable challenge), no separate failure-kind result type is needed. `AuthenticateFromChallengeAsync` returns `null` for an unusable challenge but still throws on real credential/token-endpoint failures.
- **Recovery composes.** Non-conformant-registry recovery (missing challenge, foreign realm) is a **~10-line subclass** that calls `base`, and on `null` probes via `SendWithoutAuthorizationAsync` and re-resolves — reusing the protected base helpers, no new context surface.

## Files
- `RegistryTransport`, `AuthContext`, `AuthChallenge`, `IRegistryAuthenticator`, `DefaultRegistryAuthenticator` (src)
- `RegistryAuthenticatorPrototypeTest` — 4 tests via fake transport: standard bearer flow, missing-challenge recovery, foreign-realm recovery, default-does-not-recover.

## Scope / caveats
- The token-endpoint fetch mirrors `Client`'s existing logic driven through the transport; in a full change it would **move** here rather than being duplicated, and `Client.SendCoreAsync` would collapse to `return _authenticator.SendAsync(request, ctx, (r, redirect, ct) => SendRequestAsync(r, redirect, ct), ct);`.
- Content buffering for non-idempotent retries is omitted for brevity (would carry over from `Client`).

DCO signed.
