### PR TITLE
feat(auth): add opt-in ChallengeRecovery seam for unusable 401 challenges

### DIFF
--- a/docs/auth/realm-validation.md
+++ b/docs/auth/realm-validation.md
@@ -1,0 +1,119 @@
+# Realm Validation
+
+When a registry responds to a request with a `401 Unauthorized` and a
+`WWW-Authenticate: Bearer` challenge, that challenge contains a `realm` — the URL
+of the token endpoint the client should contact to obtain a bearer token. The
+`realm` is **supplied by the (potentially untrusted) registry**, so before the
+client sends credentials there, it validates the realm with an
+[`IRealmValidator`](../../src/OrasProject.Oras/Registry/Remote/Auth/IRealmValidator.cs).
+
+This guards against a malicious or compromised registry directing the client to
+send credentials/tokens to an attacker-controlled host.
+
+## Default behavior: least-permissive
+
+`Client` uses [`DefaultRealmValidator`](../../src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs)
+unless you supply your own. It applies these rules, in order:
+
+1. Reject non-HTTP(S) schemes.
+2. Reject `http` unless `AllowInsecureHttp` is enabled.
+3. Reject realm URLs containing userinfo (e.g. `https://user:pass@host/...`).
+4. **Allow** if the realm host matches the registry host (same host, port-aware).
+5. **Allow** if the realm host is in `TrustedRealmHosts` and the realm is on the scheme-default port.
+6. Otherwise **deny**.
+
+> [!IMPORTANT]
+> `TrustedRealmHosts` is **empty by default**. Out of the box, only realms on the
+> **same host** as the registry are allowed (rule 4). The SDK is intentionally
+> host-agnostic and does **not** bake in trust for any specific registry.
+
+Many public registries serve their token endpoint from a **different** host than
+the registry itself, for example:
+
+| Registry            | Auth realm host     |
+| ------------------- | ------------------- |
+| `registry-1.docker.io` (Docker Hub) | `auth.docker.io`    |
+| `registry.gitlab.com` (GitLab)      | `gitlab.com`        |
+| `nvcr.io` (NVIDIA NGC)              | `authn.nvidia.com`  |
+
+Because these auth hosts differ from the registry host, they are **rejected by
+default** and must be opted into explicitly (see below).
+
+## Opting in to cross-host auth realms
+
+Add the realm's auth host(s) to `TrustedRealmHosts`:
+
+```csharp
+using System.Collections.Immutable;
+using OrasProject.Oras.Registry.Remote.Auth;
+
+var validator = new DefaultRealmValidator
+{
+    TrustedRealmHosts = ImmutableHashSet.Create(
+        "auth.docker.io",       // Docker Hub (registry-1.docker.io)
+        "gitlab.com",           // GitLab (registry.gitlab.com)
+        "authn.nvidia.com",     // NVIDIA NGC (nvcr.io)
+        "login.mycompany.com")  // your enterprise auth endpoint
+};
+
+var client = new Client(httpClient)
+{
+    RealmValidator = validator
+};
+```
+
+`TrustedRealmHosts` accepts any `IReadOnlySet<string>`. Prefer an
+[`ImmutableHashSet<string>`](https://learn.microsoft.com/dotnet/api/system.collections.immutable.immutablehashset-1):
+the trusted-host allowlist is fixed configuration, so an immutable set makes
+that intent explicit and is safe to share across clients. The validator also
+snapshots the set on assignment, so later mutations to a mutable collection you
+passed in have no effect.
+
+Hostnames are normalized (lowercased, trailing dots stripped) and the match is
+case-insensitive. A trusted host is still required to be on the default port for
+its scheme and to pass the scheme/userinfo checks above.
+
+## Local development over HTTP
+
+For a registry running on `localhost` without TLS, enable `AllowInsecureHttp`:
+
+```csharp
+var validator = new DefaultRealmValidator { AllowInsecureHttp = true };
+var client = new Client(httpClient) { RealmValidator = validator };
+```
+
+This only relaxes the scheme check; the same-host / trusted-host rules still apply.
+
+## Custom validators
+
+For full control (for example, allowing any auth host within a corporate domain
+suffix), implement `IRealmValidator` and assign it to `Client.RealmValidator`:
+
+```csharp
+public class CorporateDomainRealmValidator : IRealmValidator
+{
+    private readonly string _allowedSuffix;
+
+    public CorporateDomainRealmValidator(string allowedDomainSuffix)
+        => _allowedSuffix = allowedDomainSuffix.ToLowerInvariant();
+
+    public Task<bool> IsRealmAllowedAsync(
+        Uri registryUri, Uri realmUri, CancellationToken cancellationToken = default)
+    {
+        if (!realmUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(false);
+        }
+
+        var host = realmUri.Host.ToLowerInvariant();
+        return Task.FromResult(host.EndsWith(_allowedSuffix, StringComparison.Ordinal));
+    }
+}
+```
+
+## Runnable examples
+
+See
+[`examples/OrasProject.Oras.Examples.RealmValidation`](../../examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs)
+for runnable versions of the snippets above, including
+`CreateClientTrustingWellKnownPublicRegistries`.

--- a/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #region Usage
+using System.Collections.Immutable;
 using OrasProject.Oras.Registry.Remote.Auth;
 
 namespace OrasProject.Oras.Examples.RealmValidation;
@@ -29,18 +30,45 @@ public static class RealmValidationExamples
     {
         ArgumentNullException.ThrowIfNull(httpClient);
 
-        // DefaultRealmValidator ships with auth.docker.io and
-        // gitlab.com pre-configured. You can override the trusted
-        // hosts to include your organization's auth endpoints.
+        // DefaultRealmValidator ships with NO trusted hosts: by default
+        // only realms on the same host as the registry are allowed. To
+        // trust a registry whose auth realm lives on a different host,
+        // list those auth hosts explicitly — for example your
+        // organization's auth endpoints.
+        //
+        // Prefer an ImmutableHashSet<string> here: the trusted-host
+        // allowlist is fixed configuration, and an immutable set makes
+        // that intent explicit and is safe to share across clients.
         var validator = new DefaultRealmValidator
         {
-            TrustedRealmHosts = new HashSet<string>
-            {
-                "auth.docker.io",
-                "gitlab.com",
+            TrustedRealmHosts = ImmutableHashSet.Create(
                 "login.mycompany.com",
-                "auth.internal.example.com",
-            }
+                "auth.internal.example.com")
+        };
+
+        return new Client(httpClient)
+        {
+            RealmValidator = validator
+        };
+    }
+
+    /// <summary>
+    /// Opts into well-known public registries whose auth realm host
+    /// differs from the registry host (Docker Hub, GitLab, NVIDIA NGC).
+    /// These are intentionally NOT trusted by default — the SDK is
+    /// host-agnostic — so callers enable them explicitly.
+    /// </summary>
+    public static Client CreateClientTrustingWellKnownPublicRegistries(
+        HttpClient httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = ImmutableHashSet.Create(
+                "auth.docker.io",    // Docker Hub (registry-1.docker.io)
+                "gitlab.com",        // GitLab (registry.gitlab.com)
+                "authn.nvidia.com")  // NVIDIA NGC (nvcr.io)
         };
 
         return new Client(httpClient)

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveries.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveries.cs
@@ -1,0 +1,31 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Built-in <see cref="ChallengeRecoveryHandler"/> strategies.
+/// </summary>
+public static class ChallengeRecoveries
+{
+    /// <summary>
+    /// Recovers by re-deriving the challenge from a credential-free request to the same URL. It
+    /// applies only when the failed attempt carried a cached token (a stale-token rejection) and the
+    /// request is replayable; the client then re-runs the recovered response through its standard
+    /// flow. This is host-agnostic — it keys off the shape of the failure, not registry names.
+    /// </summary>
+    public static ChallengeRecoveryHandler ColdProbe { get; } = static async (context, cancellationToken) =>
+        context.AttachedCachedToken && context.CanReplay
+            ? await context.ProbeWithoutAuthorizationAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveryHandler.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveryHandler.cs
@@ -1,0 +1,47 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Attempts to recover from an HTTP 401 whose challenge the standard authentication flow could not
+/// use — for example a registry that omits the <c>WWW-Authenticate</c> challenge when a stale token
+/// is presented, or returns one whose realm points at a different host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The client consults a recovery handler only after standard resolution of the 401 has failed to
+/// produce a usable challenge, and only for a request that carried a cached token
+/// (<see cref="FailedChallenge.AttachedCachedToken"/>) and is replayable
+/// (<see cref="FailedChallenge.CanReplay"/>). Credential and token-endpoint failures are surfaced as
+/// exceptions and never reach a recovery handler, so recovery cannot mask a real authentication error.
+/// </para>
+/// <para>
+/// Return a replacement response for the client to continue from — typically the result of
+/// <see cref="FailedChallenge.ProbeWithoutAuthorizationAsync"/>, which the client re-runs through the
+/// standard flow (so a recovered challenge is fetched/cached normally, and an already-successful
+/// response is returned as-is) — or <c>null</c> to give up, in which case the client falls back to its
+/// default behavior for the original 401.
+/// </para>
+/// <para>See <see cref="ChallengeRecoveries.ColdProbe"/> for the built-in cold-probe recovery.</para>
+/// </remarks>
+/// <param name="context">The failed 401 exchange, plus a credential-free probe primitive.</param>
+/// <param name="cancellationToken">A token to cancel the operation.</param>
+/// <returns>A replacement response to continue from, or <c>null</c> to give up.</returns>
+public delegate Task<HttpResponseMessage?> ChallengeRecoveryHandler(
+    FailedChallenge context,
+    CancellationToken cancellationToken);

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -271,6 +271,15 @@ public class Client : IClient
     private IRealmValidator _realmValidator = new DefaultRealmValidator();
 
     /// <summary>
+    /// An optional recovery handler consulted when standard resolution of a 401 fails to produce a
+    /// usable challenge (e.g. a non-conformant registry that omits the challenge on a token-carrying
+    /// 401, or points its realm at a different host). Defaults to <c>null</c> — no recovery, i.e. the
+    /// standard give-up behavior. Set to <see cref="ChallengeRecoveries.ColdProbe"/> (or a custom
+    /// handler) to opt in.
+    /// </summary>
+    public ChallengeRecoveryHandler? ChallengeRecovery { get; init; }
+
+    /// <summary>
     /// ScopeManager is an instance to manage scopes.
     /// </summary>
     public ScopeManager ScopeManager { get; set; } = new();
@@ -670,6 +679,7 @@ public class Client : IClient
                     throw new ArgumentException("originalRequest.RequestUri or originalRequest.RequestUri.Authority property is null.", nameof(originalRequest));
         var requestAttempt1 = await originalRequest.CloneAsync(rewindContent: false, cancellationToken).ConfigureAwait(false);
         var attemptedKey = string.Empty;
+        var attachedCachedToken = false;
 
         // attempt to send request with cached auth token
         if (Cache.TryGetScheme(host, out var schemeFromCache, partitionId))
@@ -681,6 +691,7 @@ public class Client : IClient
                         if (Cache.TryGetToken(host, schemeFromCache, string.Empty, out var basicToken, partitionId))
                         {
                             requestAttempt1.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicToken);
+                            attachedCachedToken = true;
                         }
 
                         break;
@@ -692,6 +703,7 @@ public class Client : IClient
                         if (Cache.TryGetToken(host, schemeFromCache, attemptedKey, out var bearerToken, partitionId))
                         {
                             requestAttempt1.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+                            attachedCachedToken = true;
                         }
                         break;
                     }
@@ -704,29 +716,95 @@ public class Client : IClient
             return response1;
         }
 
+        // Resolve the 401 through the standard challenge flow. This never throws for a structurally
+        // unusable challenge (it reports the reason instead); it DOES throw for credential/token
+        // failures, so those propagate and are never eligible for recovery.
+        StandardAuthResult resolution;
+        try
+        {
+            resolution = await ResolveStandardChallengeAsync(
+                originalRequest, response1, host, partitionId, attemptedKey, allowAutoRedirect, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            response1.Dispose();
+            throw;
+        }
+
+        if (resolution.Response != null)
+        {
+            response1.Dispose();
+            return resolution.Response;
+        }
+
+        // Standard resolution dead-ended on a challenge it could not use. Consult the optional recovery
+        // handler; it decides whether the failure is recoverable (e.g. a stale-token rejection) and, if
+        // so, returns a response to continue from. Conformant registries never reach here.
+        if (ChallengeRecovery != null)
+        {
+            HttpResponseMessage? recovered;
+            try
+            {
+                recovered = await InvokeChallengeRecoveryAsync(
+                    originalRequest, response1, host, partitionId, attemptedKey, attachedCachedToken, allowAutoRedirect, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                response1.Dispose();
+                throw;
+            }
+
+            if (recovered != null)
+            {
+                response1.Dispose();
+                return recovered;
+            }
+        }
+
+        // No recovery configured, or recovery gave up: preserve the original behavior for this 401.
+        return HandleUnusableChallenge(response1, resolution, host);
+    }
+
+    /// <summary>
+    /// Runs the standard 401 challenge resolution: parse the <c>WWW-Authenticate</c> challenge and,
+    /// for a recognized scheme, fetch/replay credentials. Returns a resolved response on success, or a
+    /// <see cref="StandardAuthResult"/> describing why the challenge was structurally unusable. Throws
+    /// only for genuine credential/token-endpoint failures (never for an unusable challenge), so a
+    /// caller can distinguish "the registry withheld a usable challenge" from "authentication failed".
+    /// </summary>
+    private async Task<StandardAuthResult> ResolveStandardChallengeAsync(
+        HttpRequestMessage originalRequest,
+        HttpResponseMessage unauthorizedResponse,
+        string host,
+        string? partitionId,
+        string attemptedKey,
+        bool allowAutoRedirect,
+        CancellationToken cancellationToken)
+    {
         var (schemeFromChallenge, parameters) =
-            Challenge.ParseChallenge(response1.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
+            Challenge.ParseChallenge(unauthorizedResponse.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
 
         // Attempt again with credentials for recognized schemes
         switch (schemeFromChallenge)
         {
             case Challenge.Scheme.Basic:
                 {
-                    response1.Dispose();
                     var basicAuthToken = await FetchBasicAuthAsync(host, cancellationToken).ConfigureAwait(false);
                     Cache.SetCache(host, schemeFromChallenge, string.Empty, basicAuthToken, partitionId);
 
                     // Attempt again with basic token
                     var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
                     requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicAuthToken);
-                    return await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    var basicResponse = await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    return StandardAuthResult.Resolved(basicResponse);
                 }
             case Challenge.Scheme.Bearer:
                 {
-                    response1.Dispose();
                     if (parameters == null)
                     {
-                        throw new AuthenticationException("Missing parameters in the Www-Authenticate challenge.");
+                        return StandardAuthResult.Unusable(ChallengeFailureKind.MissingParameters);
                     }
 
                     var existingScopes = ScopeManager.GetScopesForHost(host);
@@ -753,33 +831,27 @@ public class Client : IClient
 
                         if (response2.StatusCode != HttpStatusCode.Unauthorized)
                         {
-                            return response2;
+                            return StandardAuthResult.Resolved(response2);
                         }
                         response2.Dispose();
                     }
 
                     if (!parameters.TryGetValue("realm", out var realm))
                     {
-                        // 'realm' is required as it specifies the token endpoint URL for Bearer authentication.
-                        throw new KeyNotFoundException("Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
+                        // 'realm' is required as it specifies the token endpoint URL for Bearer auth.
+                        return StandardAuthResult.Unusable(ChallengeFailureKind.MissingRealm);
                     }
 
                     // Validate realm URL before sending credentials.
-                    if (!Uri.TryCreate(
-                            realm, UriKind.Absolute,
-                            out var realmUri))
+                    if (!Uri.TryCreate(realm, UriKind.Absolute, out var realmUri))
                     {
-                        throw new AuthenticationException(
-                            $"Invalid realm URL: '{realm}'");
+                        return StandardAuthResult.Unusable(ChallengeFailureKind.InvalidRealm, realm);
                     }
 
                     var registryUri = originalRequest.RequestUri!;
-                    if (!await RealmValidator.IsRealmAllowedAsync(
-                            registryUri, realmUri, cancellationToken)
-                        .ConfigureAwait(false))
+                    if (!await RealmValidator.IsRealmAllowedAsync(registryUri, realmUri, cancellationToken).ConfigureAwait(false))
                     {
-                        throw new AuthenticationException(
-                            $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Authority}'.");
+                        return StandardAuthResult.Unusable(ChallengeFailureKind.DeniedRealm, realm, realmUri);
                     }
 
                     if (!parameters.TryGetValue("service", out var service))
@@ -801,11 +873,175 @@ public class Client : IClient
 
                     var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
                     requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
-                    return await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    var bearerResponse = await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    return StandardAuthResult.Resolved(bearerResponse);
                 }
             default:
-                return response1;
+                return StandardAuthResult.Unusable(ChallengeFailureKind.NoUsableScheme);
         }
+    }
+
+    /// <summary>
+    /// Invokes the configured <see cref="ChallengeRecovery"/> handler for an unusable 401 and continues
+    /// from whatever it returns: a non-401 response is treated as success (e.g. anonymous access); a
+    /// fresh 401 is re-run through <see cref="ResolveStandardChallengeAsync"/> exactly once (using this
+    /// client's own collaborators). Returns the response to continue from, or <c>null</c> to give up.
+    /// The cold probe carries no token, so a recovered 401 cannot re-enter recovery — bounded to one pass.
+    /// </summary>
+    private async Task<HttpResponseMessage?> InvokeChallengeRecoveryAsync(
+        HttpRequestMessage originalRequest,
+        HttpResponseMessage unauthorizedResponse,
+        string host,
+        string? partitionId,
+        string attemptedKey,
+        bool attachedCachedToken,
+        bool allowAutoRedirect,
+        CancellationToken cancellationToken)
+    {
+        var context = new FailedChallenge(
+            unauthorizedResponse,
+            host,
+            attachedCachedToken,
+            canReplay: CanReplayWithoutAuthorization(originalRequest),
+            probe: ct => ProbeWithoutAuthorizationAsync(originalRequest, allowAutoRedirect, ct));
+
+        var recovered = await ChallengeRecovery!(context, cancellationToken).ConfigureAwait(false);
+        if (recovered == null)
+        {
+            return null;
+        }
+
+        if (recovered.StatusCode != HttpStatusCode.Unauthorized)
+        {
+            // The registry served the request without (usable) authorization, e.g. anonymous access.
+            return recovered;
+        }
+
+        // The recovery produced a fresh challenge. Re-derive auth from it once, with our collaborators.
+        StandardAuthResult retry;
+        try
+        {
+            retry = await ResolveStandardChallengeAsync(
+                originalRequest, recovered, host, partitionId, attemptedKey, allowAutoRedirect, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            recovered.Dispose();
+            throw;
+        }
+
+        // Either a resolved response (return it) or still unusable (null → caller falls back). Either
+        // way the cold-probe 401 is superseded and can be released.
+        recovered.Dispose();
+        return retry.Response;
+    }
+
+    /// <summary>
+    /// Re-sends <paramref name="originalRequest"/> with no <c>Authorization</c> header to elicit a
+    /// fresh challenge from a registry that withheld a usable one for a cached token.
+    /// </summary>
+    private async Task<HttpResponseMessage> ProbeWithoutAuthorizationAsync(
+        HttpRequestMessage originalRequest,
+        bool allowAutoRedirect,
+        CancellationToken cancellationToken)
+    {
+        var probe = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+        probe.Headers.Authorization = null;
+        return await SendRequestAsync(probe, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="request"/> can be safely re-sent without authorization — restricted to
+    /// idempotent GET/HEAD so a probe never replays a mutating request.
+    /// </summary>
+    private static bool CanReplayWithoutAuthorization(HttpRequestMessage request)
+        => request.Method == HttpMethod.Get || request.Method == HttpMethod.Head;
+
+    /// <summary>
+    /// Reproduces the client's default behavior for a structurally unusable challenge when no recovery
+    /// applies: an unrecognized scheme yields the original 401; a malformed Bearer challenge throws the
+    /// same exception the standard flow has always thrown.
+    /// </summary>
+    private static HttpResponseMessage HandleUnusableChallenge(
+        HttpResponseMessage unauthorizedResponse, StandardAuthResult resolution, string host)
+    {
+        switch (resolution.FailureKind)
+        {
+            case ChallengeFailureKind.MissingParameters:
+                unauthorizedResponse.Dispose();
+                throw new AuthenticationException("Missing parameters in the Www-Authenticate challenge.");
+            case ChallengeFailureKind.MissingRealm:
+                unauthorizedResponse.Dispose();
+                throw new KeyNotFoundException("Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
+            case ChallengeFailureKind.InvalidRealm:
+                unauthorizedResponse.Dispose();
+                throw new AuthenticationException($"Invalid realm URL: '{resolution.Realm}'");
+            case ChallengeFailureKind.DeniedRealm:
+                unauthorizedResponse.Dispose();
+                throw new AuthenticationException(
+                    $"Authentication realm '{resolution.RealmUri}' is not allowed for registry '{host}'.");
+            default:
+                // NoUsableScheme: no recognized challenge scheme; return the original 401 to the caller.
+                return unauthorizedResponse;
+        }
+    }
+
+    /// <summary>
+    /// The outcome of <see cref="ResolveStandardChallengeAsync"/>: either a resolved response, or the
+    /// reason the challenge could not be used.
+    /// </summary>
+    private readonly struct StandardAuthResult
+    {
+        private StandardAuthResult(HttpResponseMessage? response, ChallengeFailureKind failureKind, string? realm, Uri? realmUri)
+        {
+            Response = response;
+            FailureKind = failureKind;
+            Realm = realm;
+            RealmUri = realmUri;
+        }
+
+        /// <summary>The resolved response, or <c>null</c> when the challenge was unusable.</summary>
+        public HttpResponseMessage? Response { get; }
+
+        /// <summary>Why the challenge was unusable; <see cref="ChallengeFailureKind.None"/> when resolved.</summary>
+        public ChallengeFailureKind FailureKind { get; }
+
+        /// <summary>The raw realm value, when relevant to the failure.</summary>
+        public string? Realm { get; }
+
+        /// <summary>The parsed realm URI, when relevant to the failure.</summary>
+        public Uri? RealmUri { get; }
+
+        public static StandardAuthResult Resolved(HttpResponseMessage response)
+            => new(response, ChallengeFailureKind.None, null, null);
+
+        public static StandardAuthResult Unusable(ChallengeFailureKind failureKind, string? realm = null, Uri? realmUri = null)
+            => new(null, failureKind, realm, realmUri);
+    }
+
+    /// <summary>
+    /// The reason the standard flow could not use a 401's challenge.
+    /// </summary>
+    private enum ChallengeFailureKind
+    {
+        /// <summary>The challenge was resolved; not a failure.</summary>
+        None,
+
+        /// <summary>No recognized authentication scheme in the challenge (e.g. no challenge at all).</summary>
+        NoUsableScheme,
+
+        /// <summary>A Bearer challenge with no parameters.</summary>
+        MissingParameters,
+
+        /// <summary>A Bearer challenge missing the required <c>realm</c> parameter.</summary>
+        MissingRealm,
+
+        /// <summary>A Bearer challenge whose <c>realm</c> is not an absolute URI.</summary>
+        InvalidRealm,
+
+        /// <summary>A Bearer challenge whose <c>realm</c> was rejected by the realm validator.</summary>
+        DeniedRealm,
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -30,8 +30,10 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// <item>Reject non-HTTP(S) schemes.</item>
 /// <item>Reject HTTP unless <see cref="AllowInsecureHttp"/> is true.</item>
 /// <item>Reject realm URLs containing userinfo.</item>
-/// <item>Allow if realm host matches the registry host (same host).</item>
-/// <item>Allow if realm host is in <see cref="TrustedRealmHosts"/>.</item>
+/// <item>Allow if the realm host and effective port match the
+/// registry (same host and port).</item>
+/// <item>Allow if the realm host is in <see cref="TrustedRealmHosts"/>
+/// (empty by default) and the realm is on the scheme-default port.</item>
 /// <item>Default deny.</item>
 /// </list>
 /// </remarks>
@@ -44,21 +46,27 @@ public sealed class DefaultRealmValidator : IRealmValidator
     public bool AllowInsecureHttp { get; init; }
 
     /// <summary>
-    /// Explicit set of trusted realm hostnames (case-insensitive).
-    /// Realms matching these hosts are allowed after basic URI safety
-    /// checks (scheme policy and userinfo rejection).
+    /// Explicit set of trusted realm hostnames (case-insensitive) whose
+    /// auth realm host differs from the registry host. Realms matching
+    /// these hosts are allowed after basic URI safety checks (scheme
+    /// policy and userinfo rejection).
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Pre-populated with well-known registries whose auth realm
-    /// host differs from the registry host:
+    /// <b>Empty by default.</b> The validator ships with no trusted
+    /// hosts, so out of the box only realms on the <em>same host</em>
+    /// (and effective port) as the registry are allowed. The SDK is
+    /// intentionally host-agnostic and does not bake in trust for any
+    /// specific registry.
     /// </para>
-    /// <list type="bullet">
-    /// <item><c>auth.docker.io</c> — Docker Hub
-    /// (registry: registry-1.docker.io)</item>
-    /// <item><c>gitlab.com</c> — GitLab Container Registry
-    /// (registry: registry.gitlab.com)</item>
-    /// </list>
+    /// <para>
+    /// To allow a registry whose auth realm lives on a different host
+    /// (for example Docker Hub's <c>auth.docker.io</c>, GitLab's
+    /// <c>gitlab.com</c>, or NVIDIA NGC's <c>authn.nvidia.com</c>),
+    /// configure this set explicitly or supply a custom
+    /// <see cref="IRealmValidator"/>. See the realm-validation examples
+    /// and <c>docs/auth/realm-validation.md</c>.
+    /// </para>
     /// <para>
     /// Values are normalized (lowercased, trailing dots stripped)
     /// and frozen on assignment. Mutations to the original
@@ -75,10 +83,7 @@ public sealed class DefaultRealmValidator : IRealmValidator
             .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
-    private IReadOnlySet<string> _trustedRealmHosts =
-        FrozenSet.ToFrozenSet(
-            new[] { "auth.docker.io", "gitlab.com" },
-            StringComparer.OrdinalIgnoreCase);
+    private IReadOnlySet<string> _trustedRealmHosts = FrozenSet<string>.Empty;
 
     /// <inheritdoc/>
     public Task<bool> IsRealmAllowedAsync(

--- a/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
@@ -1,0 +1,80 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// The context passed to a <see cref="ChallengeRecoveryHandler"/>: an HTTP 401 whose challenge the
+/// standard flow could not use, plus a credential-free probe primitive to re-derive a usable one.
+/// This is plain data; it holds no client reference.
+/// </summary>
+public sealed class FailedChallenge
+{
+    private readonly Func<CancellationToken, Task<HttpResponseMessage>> _probe;
+
+    internal FailedChallenge(
+        HttpResponseMessage unauthorizedResponse,
+        string host,
+        bool attachedCachedToken,
+        bool canReplay,
+        Func<CancellationToken, Task<HttpResponseMessage>> probe)
+    {
+        UnauthorizedResponse = unauthorizedResponse;
+        Host = host;
+        AttachedCachedToken = attachedCachedToken;
+        CanReplay = canReplay;
+        _probe = probe;
+    }
+
+    /// <summary>The 401 response, including whatever (unusable) <c>WWW-Authenticate</c> it carried.</summary>
+    public HttpResponseMessage UnauthorizedResponse { get; }
+
+    /// <summary>The registry authority (host, with port when non-default) that issued the challenge.</summary>
+    public string Host { get; }
+
+    /// <summary>
+    /// <c>true</c> when the failed attempt carried a cached token — i.e. this 401 is likely a
+    /// stale-token rejection rather than a first-time challenge.
+    /// </summary>
+    public bool AttachedCachedToken { get; }
+
+    /// <summary>
+    /// <c>true</c> when the original request can be safely re-sent without authorization
+    /// (an idempotent GET/HEAD). <see cref="ProbeWithoutAuthorizationAsync"/> requires it.
+    /// </summary>
+    public bool CanReplay { get; }
+
+    /// <summary>
+    /// Re-sends the original request with no <c>Authorization</c> header to elicit a fresh challenge.
+    /// The returned response is owned by the caller and must be disposed (or returned to the client).
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The response to the credential-free request.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="CanReplay"/> is <c>false</c>.</exception>
+    public Task<HttpResponseMessage> ProbeWithoutAuthorizationAsync(CancellationToken cancellationToken = default)
+    {
+        if (!CanReplay)
+        {
+            throw new InvalidOperationException(
+                "The original request cannot be safely replayed without authorization " +
+                "because it is not an idempotent GET or HEAD request.");
+        }
+
+        return _probe(cancellationToken);
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -1,0 +1,363 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Authentication;
+using Moq;
+using Moq.Protected;
+using OrasProject.Oras.Registry.Remote.Auth;
+using OrasProject.Oras.Registry.Remote.Exceptions;
+using static OrasProject.Oras.Tests.Remote.Util.Util;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+/// <summary>
+/// Tests for the opt-in <see cref="Client.ChallengeRecovery"/> seam and the built-in
+/// <see cref="ChallengeRecoveries.ColdProbe"/> handler. These cover non-conformant upstreams that
+/// mishandle a stale cached token (a registry that omits the challenge, or points its realm at a
+/// different host), while proving the seam is inert for conformant registries and never masks a
+/// genuine credential failure.
+/// </summary>
+public class ChallengeRecoveryTest
+{
+    private const string _staleToken = "stale_bearer_token";
+    private const string _freshToken = "fresh_access_token";
+    private const string _requestPath = "/v2/redis/manifests/8.6.4";
+    private const string _scope = "repository:redis:pull";
+
+    // The default Client cache is a process-wide shared MemoryCache. Use a unique host per test so
+    // cache entries never collide across tests running in parallel.
+    private static string NewHost() => $"reg-{Guid.NewGuid():N}.example.com";
+
+    private static HttpResponseMessage Ok(HttpRequestMessage req)
+        => new(HttpStatusCode.OK) { RequestMessage = req };
+
+    private static HttpResponseMessage TokenResponse(HttpRequestMessage req)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent($"{{\"access_token\":\"{_freshToken}\"}}"),
+            RequestMessage = req
+        };
+
+    private static HttpResponseMessage Unauthorized(HttpRequestMessage req, string? realm)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+        if (realm != null)
+        {
+            response.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
+                "Bearer", $"realm=\"{realm}\",service=\"registry\",scope=\"{_scope}\""));
+        }
+        return response;
+    }
+
+    private static bool IsTokenEndpoint(HttpRequestMessage req)
+        => req.RequestUri!.AbsolutePath.EndsWith("/token");
+
+    private static bool IsRegistryProbe(HttpRequestMessage req)
+        => req.RequestUri!.AbsolutePath == _requestPath && req.Headers.Authorization == null;
+
+    // Seeds a stale cached bearer token so attempt 1 attaches it (mirrors a real stale-token pull).
+    private static void SeedStaleToken(Client client, string host)
+        => client.Cache.SetCache(host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+
+    // Verifies attempt 1 actually carried the stale token — otherwise the request would degrade to a
+    // credential-free probe and quietly exercise the wrong code path.
+    private static void VerifyStaleTokenSent(Mock<System.Net.Http.DelegatingHandler> mockHandler)
+        => mockHandler.Protected().Verify(
+            "SendAsync", Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == _requestPath &&
+                req.Headers.Authorization != null &&
+                req.Headers.Authorization.Parameter == _staleToken),
+            ItExpr.IsAny<CancellationToken>());
+
+    private static void VerifyFreshTokenSent(Mock<System.Net.Http.DelegatingHandler> mockHandler)
+        => mockHandler.Protected().Verify(
+            "SendAsync", Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == _requestPath &&
+                req.Headers.Authorization != null &&
+                req.Headers.Authorization.Parameter == _freshToken),
+            ItExpr.IsAny<CancellationToken>());
+
+    private static void VerifyColdProbe(Mock<System.Net.Http.DelegatingHandler> mockHandler, Times times)
+        => mockHandler.Protected().Verify(
+            "SendAsync", times,
+            ItExpr.Is<HttpRequestMessage>(req => IsRegistryProbe(req)),
+            ItExpr.IsAny<CancellationToken>());
+
+    private static void VerifyTokenFetch(Mock<System.Net.Http.DelegatingHandler> mockHandler, Times times)
+        => mockHandler.Protected().Verify(
+            "SendAsync", times,
+            ItExpr.Is<HttpRequestMessage>(req => IsTokenEndpoint(req)),
+            ItExpr.IsAny<CancellationToken>());
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_NoChallengeOnStaleToken_ColdProbeRecovers()
+    {
+        // Arrange: dhi.io-style — a stale cached token provokes a 401 with NO WWW-Authenticate
+        // challenge, but a credential-free request to the same URL yields a usable Bearer challenge.
+        var host = NewHost();
+        var coldRealm = $"https://{host}/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, realm: null); // stale token → no challenge
+            return Unauthorized(req, coldRealm);                             // cold probe → usable challenge
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: recovered to 200 via a cold probe + a freshly fetched token.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyFreshTokenSent(mockHandler);
+    }
+
+    [Fact]
+    public async Task SendAsync_NoChallengeOnStaleToken_WithoutRecovery_ReturnsOriginal401()
+    {
+        // Arrange: identical to the dhi case, but recovery is NOT configured (default).
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return Unauthorized(req, $"https://{host}/token");
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object)); // ChallengeRecovery == null
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the original 401 is returned unchanged — no cold probe, no token fetch.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Never());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_DeniedRealmOnStaleToken_ColdProbeRecovers()
+    {
+        // Arrange: nvcr.io-style — a stale cached token provokes a 401 whose realm points at a foreign
+        // host (rejected by the realm validator), but a cold request yields a same-host (allowed) realm.
+        var host = NewHost();
+        var foreignRealm = "https://authn.nvidia.com/token";
+        var coldRealm = $"https://{host}/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req) && req.RequestUri!.Host == host) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, foreignRealm); // stale → foreign realm
+            return Unauthorized(req, coldRealm);                              // cold → same-host realm
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: recovered to 200 via the cold, same-host realm.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyFreshTokenSent(mockHandler);
+    }
+
+    [Fact]
+    public async Task SendAsync_DeniedRealmOnStaleToken_WithoutRecovery_Throws()
+    {
+        // Arrange: identical to the nvcr case, but recovery is NOT configured (default).
+        var host = NewHost();
+        var foreignRealm = "https://authn.nvidia.com/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req) && req.RequestUri!.Host == host) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, foreignRealm);
+            return Unauthorized(req, $"https://{host}/token");
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object)); // ChallengeRecovery == null
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act + Assert: the foreign realm is rejected exactly as before — no cold probe masks it.
+        var ex = await Assert.ThrowsAsync<AuthenticationException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+        Assert.Contains("not allowed", ex.Message);
+        VerifyColdProbe(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_AnonymousColdProbe_ReturnsResponseWithoutTokenFetch()
+    {
+        // Arrange: a stale token provokes a no-challenge 401, but the resource is actually served
+        // anonymously — the cold probe returns 200 directly, so no token is fetched.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return Ok(req); // cold probe (no auth) → anonymous 200
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the anonymous 200 is returned, and no token endpoint was contacted.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_UsableChallengeButBadCredentials_DoesNotFireRecovery()
+    {
+        // Arrange: the stale token yields a perfectly usable challenge (allowed realm), but the token
+        // endpoint rejects the credentials. Recovery must NOT fire and must NOT mask the failure.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            return Unauthorized(req, $"https://{host}/token"); // usable challenge for stale token
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act + Assert: the genuine token-endpoint failure surfaces; recovery never cold-probes.
+        await Assert.ThrowsAsync<ResponseException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_ConformantRegistry_RecoveryNeverFires()
+    {
+        // Arrange: a conformant registry (no cached token) with recovery configured. The first
+        // (credential-free) request already yields a usable challenge, so recovery is never reached
+        // and adds no extra request.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            return Unauthorized(req, $"https://{host}/token"); // normal challenge on the first request
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: 200, and the registry saw exactly one credential-free request (the initial one) —
+        // recovery did not add a second cold probe.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyFreshTokenSent(mockHandler);
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_ColdProbeAlsoUnusable_GivesUpAfterSingleProbe()
+    {
+        // Arrange: pathological upstream — both the stale-token attempt AND the cold probe return a
+        // no-challenge 401. Recovery must probe exactly once, then give up and return the original 401
+        // (no infinite loop).
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            return Unauthorized(req, realm: null); // every registry request → no challenge
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: original 401 returned; exactly one cold probe (bounded); no token fetch.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
@@ -299,25 +299,57 @@ public class DefaultRealmValidatorTest
             Realm("http://myreg.io/token")));
     }
 
-    [Fact]
-    public async Task TrustedHostNotAffectedBySchemeBlock()
+    [Theory]
+    [InlineData(
+        "https://registry-1.docker.io/v2/",
+        "https://auth.docker.io/token",
+        "auth.docker.io")]
+    [InlineData(
+        "https://registry.gitlab.com/v2/",
+        "https://gitlab.com/jwt/auth",
+        "gitlab.com")]
+    [InlineData(
+        "https://nvcr.io/v2/",
+        "https://authn.nvidia.com/token",
+        "authn.nvidia.com")]
+    public async Task WellKnownPublicRegistry_RejectedByDefault_AllowedWhenConfigured(
+        string registry, string realm, string trustedHost)
     {
-        // Docker Hub: auth.docker.io is in the default trusted
-        // list — works without explicit TrustedRealmHosts.
-        var validator = new DefaultRealmValidator();
-        Assert.True(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
-            Realm("https://auth.docker.io/token")));
+        // Default ships with no trusted hosts: well-known public
+        // registries whose auth realm is on a different host are
+        // rejected until explicitly opted in.
+        var defaultValidator = new DefaultRealmValidator();
+        Assert.False(await defaultValidator.IsRealmAllowedAsync(
+            Reg(registry), Realm(realm)));
+
+        // Opt in by configuring the realm's auth host.
+        var configured = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                trustedHost
+            }
+        };
+        Assert.True(await configured.IsRealmAllowedAsync(
+            Reg(registry), Realm(realm)));
     }
 
     [Fact]
-    public async Task GitLabRegistry_DefaultTrusted_Allowed()
+    public async Task TrustedHost_NonDefaultPort_Rejected()
     {
-        // GitLab: gitlab.com is in the default trusted list.
-        var validator = new DefaultRealmValidator();
-        Assert.True(await validator.IsRealmAllowedAsync(
-            Reg("https://registry.gitlab.com/v2/"),
-            Realm("https://gitlab.com/jwt/auth")));
+        // A configured trusted host must still be on the default port.
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://registry.example.com/v2/"),
+            Realm("https://auth.example.com:8443/token")));
     }
 
     [Fact]
@@ -452,21 +484,35 @@ public class DefaultRealmValidatorTest
     public async Task UserinfoOnTrustedHost_Rejected()
     {
         // Userinfo check fires before trusted host check.
-        var validator = new DefaultRealmValidator();
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
+            Reg("https://registry.example.com/v2/"),
             Realm(
-                "https://user@auth.docker.io/token")));
+                "https://user@auth.example.com/token")));
     }
 
     [Fact]
     public async Task HttpOnTrustedHost_RejectedByDefault()
     {
         // HTTP scheme block applies even to trusted hosts.
-        var validator = new DefaultRealmValidator();
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
-            Realm("http://auth.docker.io/token")));
+            Reg("https://registry.example.com/v2/"),
+            Realm("http://auth.example.com/token")));
     }
 
     [Fact]
@@ -483,12 +529,19 @@ public class DefaultRealmValidatorTest
     [Fact]
     public async Task SuperstringHostname_Rejected()
     {
-        // "auth.docker.io.evil.com" is NOT "auth.docker.io"
-        var validator = new DefaultRealmValidator();
+        // "auth.example.com.evil.com" is NOT "auth.example.com"
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
+            Reg("https://registry.example.com/v2/"),
             Realm(
-                "https://auth.docker.io.evil.com/tok"
+                "https://auth.example.com.evil.com/tok"
                 )));
     }
 


### PR DESCRIPTION
## Summary

Adds a narrow, **opt-in** `ChallengeRecovery` seam to the auth `Client` so it can recover from a 401 whose `WWW-Authenticate` challenge is *structurally unusable* — the failure mode a stale cached bearer token provokes on some non-conformant upstreams:

- **dhi.io** → `401` with **no** challenge at all.
- **nvcr.io** → `401` whose realm points at a **different host** (`authn.nvidia.com`), rejected by realm validation.

For both, a credential-free request to the *same URL* yields a perfectly usable challenge. Today the engine has no way to act on that: it returns the 401 (no scheme) or throws (denied realm).

> Design decision record and the full menu of alternatives we evaluated: oras-project/oras-dotnet#405. This replaces the earlier `IRegistryAuthenticator` prototype (fork #29, closed) and the `IAuthChallengeHandler` prototype (oras-project/oras-dotnet#406, closed).

## API surface (all additive)

- `Client.ChallengeRecovery { get; init; }` — nullable `ChallengeRecoveryHandler`. **Default `null` = today's exact behavior.**
- `ChallengeRecoveryHandler` — `Task<HttpResponseMessage?> (FailedChallenge, CancellationToken)`.
- `FailedChallenge` — plain data (`UnauthorizedResponse`, `Host`, `AttachedCachedToken`, `CanReplay`) + `ProbeWithoutAuthorizationAsync(...)`, a credential-free replay primitive. Holds no `Client` reference.
- `ChallengeRecoveries.ColdProbe` — built-in, host-agnostic strategy: when the failed attempt carried a cached token and the request is replayable, re-derive the challenge from a credential-free request.

Opt in with one line:

```csharp
var client = new Client(httpClient) { ChallengeRecovery = ChallengeRecoveries.ColdProbe };
```

## How it works

`SendCoreAsync` is refactored to separate two concerns that were previously tangled in one switch:

1. **`ResolveStandardChallengeAsync`** runs the normal parse-challenge → fetch/replay-credentials flow and returns a discriminated `StandardAuthResult`. It **never throws for a structurally unusable challenge** (it reports a `ChallengeFailureKind` instead), but it **does throw for genuine credential/token-endpoint failures**.
2. **`HandleUnusableChallenge`** maps each `ChallengeFailureKind` back to the **exact** exception/return the engine has always produced — so with no recovery configured, behavior is byte-for-byte unchanged.

Recovery sits between them and only runs when standard resolution dead-ends on an unusable challenge:

- Credential/token failures throw **before** recovery is consulted → recovery can never mask a real auth error.
- The recovered response is re-run through the standard flow **once** (bounded — the cold probe carries no token, so it can't re-arm recovery): a recovered challenge is fetched/cached normally; an anonymous `200` is returned as-is.
- Gating signals (`AttachedCachedToken`, `CanReplay`) are passed honestly to the handler; `ColdProbe` enforces the stale-token + idempotency policy itself.

**No cost for conformant registries:** they resolve on the standard path and never reach recovery — no extra request, no allocation.

## Why opt-in (not default-on)

There's no performance reason — the gate excludes conformant registries entirely. It's off by default because cold-probing around a withheld/foreign challenge is *tolerance of a registry deviating from the docker/distribution de-facto auth flow* (the OCI specs don't mandate auth semantics). That's the consumer's call to make, so it's opt-in. ACR sets `ChallengeRecoveries.ColdProbe`.

## Testing

- **561/562** pass (the one failure, `SendAsync_RealmValidation_RelativeRealm_Throws`, is a pre-existing Windows-only `Uri` parsing quirk that also fails on clean `main`).
- 8 new `ChallengeRecoveryTest` cases: dhi no-challenge recover, nvcr foreign-realm recover, both **default-off** behaviors (return 401 / throw unchanged), anonymous cold success, **credential failure not masked**, conformant-registry inert, and single-probe boundedness. Each stale-token test asserts attempt 1 actually carried the stale token, so the recovery path is genuinely exercised.

## Behavior preservation

When `ChallengeRecovery == null`, every path — including the exact exception types and messages (`AuthenticationException`, `KeyNotFoundException`, realm-denied/invalid messages) and response disposal semantics — is identical to `main`.

Refs oras-project/oras-dotnet#405